### PR TITLE
fix: restoring the comparison page defaults to projects compare

### DIFF
--- a/packages/shared-components/components/projects-compare/ProjectsCompare.vue
+++ b/packages/shared-components/components/projects-compare/ProjectsCompare.vue
@@ -28,7 +28,7 @@ const prop = defineProps({
   },
 });
 
-const pageName = ref('BenchmarkCompare');
+const pageName = ref('ProjectsCompare');
 const projects = reactive<Array<SoftwareInfo>>([]);
 prop.repositories.forEach(repoName => {
   const encodedname = encodeURIComponent(repoName);


### PR DESCRIPTION
Restoring the comparison page defaults to projects compare