### PR TITLE
fix: benchmark results are taken from the latest batch

### DIFF
--- a/packages/api-server/src/services/BenchmarkService.ts
+++ b/packages/api-server/src/services/BenchmarkService.ts
@@ -83,7 +83,10 @@ export async function getBenchmarkResultByTechStack(
                                content,
                               platform
           FROM BENCHMARK
-         WHERE tech_stack = :techStack 
+          WHERE patch_id = (
+            SELECT MAX(patch_id)
+            FROM BENCHMARK
+            WHERE tech_stack = :techStack) 
       ORDER BY project_id, BENCHMARK,created_at;
   `;
 


### PR DESCRIPTION
benchmark results are taken from the latest batch