### PR TITLE
feat: sync stars and contributors

### DIFF
--- a/packages/data-model/models/GithubProjectsHistory.js
+++ b/packages/data-model/models/GithubProjectsHistory.js
@@ -18,6 +18,9 @@ export default sequelize.define(
     contributors: {
       type: DataTypes.INTEGER,
     },
+    stars: {
+      type: DataTypes.INTEGER,
+    },
   },
   {
     tableName: 'github_projects_history',

--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -1,10 +1,4 @@
-import {
-  GithubProjects,
-  GithubProjectsTable,
-  GithubProjectsHistory,
-  sequelize,
-  logger,
-} from '@orginjs/oss-evaluation-data-model';
+import { GithubProjects, GithubProjectsTable, logger } from '@orginjs/oss-evaluation-data-model';
 import { getProjectByUrl } from '../util/util.js';
 import { fetchWithTimeout } from '../util/fetchWitTimeout.js';
 import * as cheerio from 'cheerio';
@@ -18,18 +12,6 @@ export async function syncSingleProjectContributorsHandler(req, res) {
 
 export async function syncAllProjectContributorsHandler(req, res) {
   await syncAllProjectContributors();
-  res.status(200).send('success');
-}
-
-export async function storeSingleProjectContributorsHandler(req, res) {
-  const { repoUrl: repoUrl } = req.params;
-  const project = await getProjectByUrl(repoUrl);
-  await storeProjectContributors(project.id);
-  res.status(200).send('success');
-}
-
-export async function storeAllProjectContributorsHandler(req, res) {
-  await storeProjectContributors();
   res.status(200).send('success');
 }
 
@@ -56,34 +38,6 @@ async function getProjectList(projectId) {
       : {},
   });
   return projectList;
-}
-
-export async function storeProjectContributors(projectId) {
-  logger.info('Store Project Contributors');
-  // 1. get all github project
-  const projectList = await getProjectList(projectId);
-  const sumOfProject = projectList.length;
-  logger.info(`The Number of Project : ${sumOfProject}`);
-  let count = 1;
-  for (const project of projectList) {
-    logger.info('**Current Progress**: ', `${count}/${sumOfProject}`);
-    count += 1;
-    // 2. update project contributors
-    const currentDate = sequelize.literal('CURDATE()');
-    await GithubProjectsHistory.upsert(
-      {
-        projectId: project.id,
-        date: currentDate,
-        contributors: project.contributors ? project.contributors : 0,
-      },
-      {
-        where: {
-          projectId: project.id,
-          date: currentDate,
-        },
-      },
-    );
-  }
 }
 
 export default async function syncProjectContributors(projectId) {
@@ -194,33 +148,12 @@ async function getAlllContributors(repoName) {
 }
 
 export async function projectContributorsTimer() {
-  const now = new Date();
-  const currentDate = now.getDate();
-  const currentDay = now.getDay();
-  if (currentDate === 1 || currentDay === 6) {
-    // sync contributors
-    const startTime = process.hrtime();
-    logger.info('[Integration][ProjectContributors] Integration Job start');
-    await syncAllProjectContributors();
-    logger.info('[Integration][ProjectContributors] Integration Job end');
-    const endTime = process.hrtime(startTime);
-    logger.info(
-      `[Integration][ProjectContributors] The total time spent on integration : ${endTime[0]}s ${endTime[1] / 1e6}ms`,
-    );
-    if (currentDate === 1) {
-      // store contributors
-      const startStoreTime = process.hrtime();
-      logger.info('[Integration][ProjectContributorsHistory] Integration Job start');
-      await storeProjectContributors();
-      logger.info('[Integration][ProjectContributorsHistory] Integration Job end');
-      const endStoreTime = process.hrtime(startStoreTime);
-      logger.info(
-        `[Integration][ProjectContributorsHistory] The total time spent on integration : ${endStoreTime[0]}s ${endStoreTime[1] / 1e6}ms`,
-      );
-    }
-  } else {
-    logger.info(
-      '[Integration][ProjectContributors] Integration Job will be performed every Saturday or the first of every month',
-    );
-  }
+  const startTime = process.hrtime();
+  logger.info('[Integration][ProjectContributors] Integration Job start');
+  await syncAllProjectContributors();
+  logger.info('[Integration][ProjectContributors] Integration Job end');
+  const endTime = process.hrtime(startTime);
+  logger.info(
+    `[Integration][ProjectContributors] The total time spent on integration : ${endTime[0]}s ${endTime[1] / 1e6}ms`,
+  );
 }

--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -128,7 +128,6 @@ async function getContributors(repoName, page = 1) {
   // avoid situations where the project is empty
   try {
     const content = await request.json();
-    logger.info(content.length);
     return content;
   } catch (error) {
     logger.error('The project is empty:', error);

--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -127,8 +127,7 @@ async function getContributors(repoName, page = 1) {
   );
   // avoid situations where the project is empty
   try {
-    const content = await request.json();
-    return content;
+    return await request.json();
   } catch (error) {
     logger.error('The project is empty:', error);
     return [];

--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -125,9 +125,15 @@ async function getContributors(repoName, page = 1) {
       headers: header,
     },
   );
-
   // avoid situations where the project is empty
-  return request.length > 0 ? await request.json() : [];
+  try {
+    const content = await request.json();
+    logger.info(content.length);
+    return content;
+  } catch (error) {
+    logger.error('The project is empty:', error);
+    return [];
+  }
 }
 
 export async function getAlllContributors(repoName) {

--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -130,7 +130,7 @@ async function getContributors(repoName, page = 1) {
   return request.length > 0 ? await request.json() : [];
 }
 
-async function getAlllContributors(repoName) {
+export async function getAlllContributors(repoName) {
   let contributors = [];
   let page = 1;
   let list;

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -1,20 +1,24 @@
 import {
   GithubProjects,
   GithubProjectsHistory,
+  GithubProjectsTable,
   sequelize,
   logger,
 } from '@orginjs/oss-evaluation-data-model';
 import { getProjectByUrl } from '../util/util.js';
+import { fetchWithTimeout } from '../util/fetchWitTimeout.js';
+import { getAlllContributors } from './projectContributors.js';
+import * as cheerio from 'cheerio';
 
-export async function storeSingleProjectContributorsHandler(req, res) {
+export async function syncSingleProjectHistoryHandler(req, res) {
   const { repoUrl: repoUrl } = req.params;
   const project = await getProjectByUrl(repoUrl);
-  await storeProjectContributors(project.id);
+  await syncProjectHistory(project.id);
   res.status(200).send('success');
 }
 
-export async function storeAllProjectContributorsHandler(req, res) {
-  await storeProjectContributors();
+export async function syncAllProjectHistoryHandler(req, res) {
+  await syncProjectHistory();
   res.status(200).send('success');
 }
 
@@ -30,8 +34,8 @@ async function getProjectList(projectId) {
   return projectList;
 }
 
-export async function storeProjectContributors(projectId) {
-  logger.info('Store Project Contributors');
+export default async function syncProjectHistory(projectId) {
+  logger.info('Sync Project Contributors');
   // 1. get all github project
   const projectList = await getProjectList(projectId);
   const sumOfProject = projectList.length;
@@ -40,13 +44,41 @@ export async function storeProjectContributors(projectId) {
   for (const project of projectList) {
     logger.info('**Current Progress**: ', `${count}/${sumOfProject}`);
     count += 1;
-    // 2. update project contributors
+    // 2. get project information
+    let [contributors, stars] = await getProjectInformation(project.htmlUrl);
+    // check contributors
+    if (contributors == '' || contributors == undefined) {
+      contributors = (await getAlllContributors(project.fullName)).length;
+      logger.info(`GitHub API : contributors of ${project.htmlUrl} is ${contributors}`);
+    }
+    if (contributors == '' || contributors == undefined) {
+      continue;
+    }
+    // check stars
+    if (stars == '' || stars == undefined) {
+      stars = await getStars(project.fullName);
+      logger.info(`GitHub API : stars of ${project.htmlUrl} is ${stars}`);
+    }
+    if (stars == '' || stars == undefined) {
+      continue;
+    }
+    // refresh github_projects_t
+    await GithubProjectsTable.update(
+      { contributors: contributors },
+      {
+        where: {
+          id: project.id,
+        },
+      },
+    );
+    // store github_projects_history
     const currentDate = sequelize.literal('CURDATE()');
     await GithubProjectsHistory.upsert(
       {
         projectId: project.id,
         date: currentDate,
-        contributors: project.contributors ? project.contributors : 0,
+        contributors: contributors ? contributors : 0,
+        stars: stars ? stars : 0,
       },
       {
         where: {
@@ -58,13 +90,79 @@ export async function storeProjectContributors(projectId) {
   }
 }
 
-export async function projectContributorsHistoryTimer() {
-  const startStoreTime = process.hrtime();
-  logger.info('[Integration][ProjectContributorsHistory] Integration Job start');
-  await storeProjectContributors();
-  logger.info('[Integration][ProjectContributorsHistory] Integration Job end');
-  const endStoreTime = process.hrtime(startStoreTime);
+async function getProjectInformation(url) {
+  let contributors, stars;
+  try {
+    const response = await fetchWithTimeout(url, 3 * 60 * 1000);
+    if (response.ok) {
+      const text = await response.text();
+      // parse html
+      const $ = cheerio.load(text);
+      const repoName = url.match(/\/github\.com\/(.*)/)[1];
+      // get contributor
+      const content = $(`a[href="/${repoName}/graphs/contributors"]`).text();
+      if (content.length === 0) {
+        logger.info(`web crawler: ${url} does not provide contributors...`);
+        return contributors;
+      } else {
+        const regex = /(\d{1,3}(,\d{3})*(\.\d+)?)/g;
+        const contributorsArrays = content.match(regex);
+        let contributorsNumMain, contributorsNumSub;
+        contributorsNumMain = contributorsArrays[0]?.replace(/,/g, '');
+        contributorsNumSub = contributorsArrays[1]?.replace(/,/g, '');
+        // contributorsNumMain will be 5000 when it more than 5000, use contributorsNumSub to get realNumber
+        let realNumber;
+        if (contributorsNumMain === '5000') {
+          realNumber = parseInt(contributorsNumSub) + 14;
+        } else {
+          realNumber = parseInt(contributorsNumMain);
+        }
+        contributors = realNumber.toString();
+
+        logger.info(`web crawler: contributors of ${url} is ${contributors}`);
+      }
+      // get star
+      const spanStar = $('#repo-stars-counter-star');
+      if (spanStar === null) {
+        logger.info(`web crawler: ${url} does not provide stars...`);
+      } else {
+        const starValueOrigin = spanStar.attr('title');
+        stars = starValueOrigin.replace(/,/g, '');
+        logger.info(`web crawler: stars of ${url} is ${stars}`);
+      }
+    }
+  } catch (e) {
+    logger.error(`**web crawler: Url get contributors is failed !** :${url}`);
+  }
+  return [contributors, stars];
+}
+
+async function getStars(repoName) {
+  const header = process.env.GITHUB_TOKEN
+    ? {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      }
+    : {
+        'Content-Type': 'application/json',
+      };
+
+  const request = await fetch(`https://api.github.com/repos/${repoName}`, {
+    method: 'GET',
+    headers: header,
+  });
+
+  const content = await request.json();
+  return content.stargazers_count;
+}
+
+export async function projectHistoryTimer() {
+  const startTime = process.hrtime();
+  logger.info('[Integration][ProjectHistory] Integration Job start');
+  await syncProjectHistory();
+  logger.info('[Integration][ProjectHistory] Integration Job end');
+  const endTime = process.hrtime(startTime);
   logger.info(
-    `[Integration][ProjectContributorsHistory] The total time spent on integration : ${endStoreTime[0]}s ${endStoreTime[1] / 1e6}ms`,
+    `[Integration][ProjectHistory] The total time spent on integration : ${endTime[0]}s ${endTime[1] / 1e6}ms`,
   );
 }

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -103,7 +103,6 @@ async function getProjectInformation(url) {
       const content = $(`a[href="/${repoName}/graphs/contributors"]`).text();
       if (content.length === 0) {
         logger.info(`web crawler: ${url} does not provide contributors...`);
-        return contributors;
       } else {
         const regex = /(\d{1,3}(,\d{3})*(\.\d+)?)/g;
         const contributorsArrays = content.match(regex);

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -47,19 +47,16 @@ export default async function syncProjectHistory(projectId) {
     // 2. get project information
     let [contributors, stars] = await getProjectInformation(project.htmlUrl);
     // check contributors
-    if (contributors == '' || contributors == undefined) {
+    if (!contributors) {
       contributors = (await getAlllContributors(project.fullName)).length;
       logger.info(`GitHub API : contributors of ${project.htmlUrl} is ${contributors}`);
     }
-    if (contributors == '' || contributors == undefined) {
-      continue;
-    }
     // check stars
-    if (stars == '' || stars == undefined) {
+    if (!stars) {
       stars = await getStars(project.fullName);
       logger.info(`GitHub API : stars of ${project.htmlUrl} is ${stars}`);
     }
-    if (stars == '' || stars == undefined) {
+    if (!contributors && !stars) {
       continue;
     }
     // refresh github_projects_t
@@ -122,7 +119,7 @@ async function getProjectInformation(url) {
       }
       // get star
       const spanStar = $('#repo-stars-counter-star');
-      if (spanStar === null) {
+      if (!spanStar) {
         logger.info(`web crawler: ${url} does not provide stars...`);
       } else {
         const starValueOrigin = spanStar.attr('title');

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -1,0 +1,70 @@
+import {
+  GithubProjects,
+  GithubProjectsHistory,
+  sequelize,
+  logger,
+} from '@orginjs/oss-evaluation-data-model';
+import { getProjectByUrl } from '../util/util.js';
+
+export async function storeSingleProjectContributorsHandler(req, res) {
+  const { repoUrl: repoUrl } = req.params;
+  const project = await getProjectByUrl(repoUrl);
+  await storeProjectContributors(project.id);
+  res.status(200).send('success');
+}
+
+export async function storeAllProjectContributorsHandler(req, res) {
+  await storeProjectContributors();
+  res.status(200).send('success');
+}
+
+async function getProjectList(projectId) {
+  const projectList = await GithubProjects.findAll({
+    attributes: ['id', 'htmlUrl', 'fullName', 'contributors'],
+    where: projectId
+      ? {
+          id: projectId,
+        }
+      : {},
+  });
+  return projectList;
+}
+
+export async function storeProjectContributors(projectId) {
+  logger.info('Store Project Contributors');
+  // 1. get all github project
+  const projectList = await getProjectList(projectId);
+  const sumOfProject = projectList.length;
+  logger.info(`The Number of Project : ${sumOfProject}`);
+  let count = 1;
+  for (const project of projectList) {
+    logger.info('**Current Progress**: ', `${count}/${sumOfProject}`);
+    count += 1;
+    // 2. update project contributors
+    const currentDate = sequelize.literal('CURDATE()');
+    await GithubProjectsHistory.upsert(
+      {
+        projectId: project.id,
+        date: currentDate,
+        contributors: project.contributors ? project.contributors : 0,
+      },
+      {
+        where: {
+          projectId: project.id,
+          date: currentDate,
+        },
+      },
+    );
+  }
+}
+
+export async function projectContributorsHistoryTimer() {
+  const startStoreTime = process.hrtime();
+  logger.info('[Integration][ProjectContributorsHistory] Integration Job start');
+  await storeProjectContributors();
+  logger.info('[Integration][ProjectContributorsHistory] Integration Job end');
+  const endStoreTime = process.hrtime(startStoreTime);
+  logger.info(
+    `[Integration][ProjectContributorsHistory] The total time spent on integration : ${endStoreTime[0]}s ${endStoreTime[1] / 1e6}ms`,
+  );
+}

--- a/packages/integration/routes/sync.js
+++ b/packages/integration/routes/sync.js
@@ -67,9 +67,11 @@ import {
 import {
   syncSingleProjectContributorsHandler,
   syncAllProjectContributorsHandler,
+} from '../controllers/projectContributors.js';
+import {
   storeSingleProjectContributorsHandler,
   storeAllProjectContributorsHandler,
-} from '../controllers/projectContributors.js';
+} from '../controllers/projectHistory.js';
 import {
   syncAllProjectDependentCountHandler,
   syncSingleProjectDependentCountHandler,

--- a/packages/integration/routes/sync.js
+++ b/packages/integration/routes/sync.js
@@ -69,8 +69,8 @@ import {
   syncAllProjectContributorsHandler,
 } from '../controllers/projectContributors.js';
 import {
-  storeSingleProjectContributorsHandler,
-  storeAllProjectContributorsHandler,
+  syncSingleProjectHistoryHandler,
+  syncAllProjectHistoryHandler,
 } from '../controllers/projectHistory.js';
 import {
   syncAllProjectDependentCountHandler,
@@ -1152,20 +1152,20 @@ router.route('/syncSingleProjectContributors/:repoUrl').get(syncSingleProjectCon
 
 /**
  * @swagger
- * /sync/storeAllProjectContributors:
+ * /sync/syncAllProjectHistory:
  *   get:
- *     summary: store contributors of project
+ *     summary: sync project information - contributors, stars
  *     responses:
  *       200:
  *         description: success.
  */
-router.route('/storeAllProjectContributors').get(storeAllProjectContributorsHandler);
+router.route('/syncAllProjectHistory').get(syncAllProjectHistoryHandler);
 
 /**
  * @swagger
- * /sync/storeSingleProjectContributors/{repoUrl}:
+ * /sync/syncSingleProjectHistory/{repoUrl}:
  *   get:
- *     summary: store contributors of project
+ *     summary: sync project information - contributors, stars
  *     parameters:
  *      - in: path
  *        name: repoUrl
@@ -1176,7 +1176,7 @@ router.route('/storeAllProjectContributors').get(storeAllProjectContributorsHand
  *       200:
  *         description: success.
  */
-router.route('/storeSingleProjectContributors/:repoUrl').get(storeSingleProjectContributorsHandler);
+router.route('/syncSingleProjectHistory/:repoUrl').get(syncSingleProjectHistoryHandler);
 
 /**
  * @swagger

--- a/packages/integration/scheduler/config.js
+++ b/packages/integration/scheduler/config.js
@@ -30,7 +30,7 @@ export const JobConfig = {
     },
     {
       name: 'projectContributorsTimer',
-      cronScheduleTime: '0 0 * * *', // 每天 00:00 启动, 内部判断是否执行(周六或每月1号)
+      cronScheduleTime: '0 0 * * 6', // 周六 00:00
       enabled: isProduction, // only start in production environment
     },
     {

--- a/packages/integration/scheduler/config.js
+++ b/packages/integration/scheduler/config.js
@@ -38,5 +38,10 @@ export const JobConfig = {
       cronScheduleTime: '0 0 1 * *', // 每月1号 00:00
       enabled: isProduction, // only start in production environment
     },
+    {
+      name: 'projectHistoryTimer',
+      cronScheduleTime: '0 0 1 * *', // 每月1号 00:00
+      enabled: isProduction, // only start in production environment
+    },
   ],
 };

--- a/packages/integration/scheduler/job.js
+++ b/packages/integration/scheduler/job.js
@@ -8,6 +8,7 @@ import { projectDependentCountTimer } from '../controllers/projectDependentCount
 import { projectCodeSizeTimer } from '../controllers/projectCodeSize.js';
 import { projectContributorsTimer } from '../controllers/projectContributors.js';
 import { evaluateTimer } from '../controllers/evaluate.js';
+import { projectHistoryTimer } from '../controllers/projectHistory.js';
 
 function createTimer(name, pattern, timer) {
   if (!pattern) {
@@ -39,6 +40,7 @@ const taskFactory = {
   projectDependentCountTimer,
   projectContributorsTimer,
   evaluateTimer,
+  projectHistoryTimer,
   createTask: function (taskName) {
     if (!this[taskName]) {
       throw new Error(`Task ${taskName} not found`);

--- a/sql/github-history-update.sql
+++ b/sql/github-history-update.sql
@@ -1,0 +1,5 @@
+alter table github_projects_history
+    alter column contributors set default (-1);
+
+alter table github_projects_history
+    add stars int default -1 not null;


### PR DESCRIPTION
1. Decouple the logic for storing github history from the projectCrontributors.js.
2. Implement the logic for crawling GitHub star data.
3. Crawl GitHub contributors and stars information on the first day of each month.
4. Fix a bug that the returned contributor list is incorrect when using GitHub API.