### PR TITLE
fix: fix design issues with increases and total values calculation logic

### DIFF
--- a/packages/data-model/models/EvaluationSummaryHistory.js
+++ b/packages/data-model/models/EvaluationSummaryHistory.js
@@ -13,7 +13,7 @@ export default sequelize.define(
       type: DataTypes.INTEGER,
     },
     date: {
-      type: DataTypes.DATE,
+      type: DataTypes.DATEONLY,
     },
     functionScore: {
       type: DataTypes.DOUBLE,

--- a/packages/data-model/models/GithubProjectsHistory.js
+++ b/packages/data-model/models/GithubProjectsHistory.js
@@ -13,7 +13,7 @@ export default sequelize.define(
       type: DataTypes.INTEGER,
     },
     date: {
-      type: DataTypes.DATE,
+      type: DataTypes.DATEONLY,
     },
     contributors: {
       type: DataTypes.INTEGER,

--- a/packages/data-model/models/TrendHistory.js
+++ b/packages/data-model/models/TrendHistory.js
@@ -25,7 +25,7 @@ export default sequelize.define(
       type: DataTypes.INTEGER,
     },
     date: {
-      type: DataTypes.DATE,
+      type: DataTypes.DATEONLY,
     },
   },
   {

--- a/packages/integration/controllers/evaluate.js
+++ b/packages/integration/controllers/evaluate.js
@@ -5,6 +5,7 @@ import {
   Benchmark,
   EvaluationModel,
   EvaluationSummary,
+  EvaluationSummaryHistory,
   Scorecard,
   CriticalityScore,
   OpenDigger,
@@ -242,12 +243,28 @@ export async function syncAllProjectEvaluation() {
 async function storeAllEvaluationSummaryHistory() {
   // store evaluation score for all projects
   logger.info('start mysql');
-  await sequelize.query(`INSERT INTO
-  oss_evaluate_summary_history(project_id, date, function_score, quality_score, ecology_score, innovation_score)
-  SELECT project_id, CURDATE(), function_score, quality_score, ecology_score, innovation_score
-  FROM oss_evaluation_summary ON DUPLICATE KEY UPDATE
-  function_score = VALUES(function_score), quality_score = VALUES(quality_score),
-  ecology_score = VALUES(ecology_score), innovation_score = VALUES(innovation_score)`);
+  const currentDate = new Date();
+  const projectList = await EvaluationSummary.findAll({
+    attributes: ['projectId', 'functionScore', 'qualityScore', 'ecologyScore', 'innovationScore'],
+  });
+  for (const project of projectList) {
+    await EvaluationSummaryHistory.upsert(
+      {
+        projectId: project.projectId,
+        date: currentDate,
+        qualityScore: project.qualityScore ? project.qualityScore : 0,
+        functionScore: project.functionScore ? project.functionScore : 0,
+        ecologyScore: project.ecologyScore ? project.ecologyScore : 0,
+        innovationScore: project.innovationScore ? project.innovationScore : 0,
+      },
+      {
+        where: {
+          projectId: project.projectId,
+          date: currentDate,
+        },
+      },
+    );
+  }
   // store evaluation score to trend history
   await storeEvaluateTrendHistory();
 }

--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -124,7 +124,7 @@ async function getContributors(repoName, page = 1) {
       method: 'GET',
       headers: header,
     },
-  );
+  ).catch(error => logger.error('Error in fetch REST API:', error));
   // avoid situations where the project is empty
   try {
     return await request.json();

--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -1,6 +1,7 @@
 import { GithubProjects, GithubProjectsTable, logger } from '@orginjs/oss-evaluation-data-model';
 import { getProjectByUrl } from '../util/util.js';
 import { fetchWithTimeout } from '../util/fetchWitTimeout.js';
+import { fetchWithRetries } from '../util/fetchWithRetries.js';
 import * as cheerio from 'cheerio';
 
 export async function syncSingleProjectContributorsHandler(req, res) {
@@ -118,7 +119,7 @@ async function getContributors(repoName, page = 1) {
         'Content-Type': 'application/json',
       };
 
-  const request = await fetch(
+  const request = await fetchWithRetries(
     `https://api.github.com/repos/${repoName}/contributors?per_page=100&page=${page}&anon=true`,
     {
       method: 'GET',

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -11,6 +11,7 @@ import { fetchWithRetries } from '../util/fetchWithRetries.js';
 import { getAlllContributors } from './projectContributors.js';
 import * as cheerio from 'cheerio';
 import { storeGithubHistory } from './trendHistory.js';
+import { Op } from 'sequelize';
 
 export async function syncSingleProjectHistoryHandler(req, res) {
   const { repoUrl: repoUrl } = req.params;
@@ -38,9 +39,17 @@ async function getProjectList(projectId) {
 
 async function getExistRecord() {
   const existRecordList = await GithubProjectsHistory.findAll({
-    where: sequelize.literal(
-      'DATE(Date) = CURDATE() AND contributors IS NOT NULL and stars IS NOT NULL',
-    ),
+    where: {
+      contributors: {
+        [Op.ne]: null,
+      },
+      stars: {
+        [Op.ne]: null,
+      },
+      date: {
+        [Op.eq]: sequelize.fn('CURDATE'),
+      },
+    },
   }).catch(err => {
     logger.error('Error in query: ', err);
   });
@@ -60,12 +69,12 @@ export default async function syncProjectHistory(projectId) {
     logger.info('**Current Progress**: ', `${count}/${sumOfProject}`);
     count += 1;
     // 3. determine whether integration is required
-    if (existRecordList) {
-      const existData = existRecordList.find(item => item.projectId === project.id);
-      if (existData) {
-        logger.info('Record already exists, ignore this project.');
-        continue;
-      }
+    const existData = existRecordList
+      ? existRecordList.find(item => item.projectId === project.id)
+      : null;
+    if (existData) {
+      logger.info('Record already exists, ignore this project.');
+      continue;
     }
     // 4. get project information
     let [contributors, stars] = await getProjectInformation(project.htmlUrl);

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -7,6 +7,7 @@ import {
 } from '@orginjs/oss-evaluation-data-model';
 import { getProjectByUrl } from '../util/util.js';
 import { fetchWithTimeout } from '../util/fetchWitTimeout.js';
+import { fetchWithRetries } from '../util/fetchWithRetries.js';
 import { getAlllContributors } from './projectContributors.js';
 import * as cheerio from 'cheerio';
 import { storeGithubHistory } from './trendHistory.js';
@@ -166,13 +167,18 @@ async function getStars(repoName) {
         'Content-Type': 'application/json',
       };
 
-  const request = await fetch(`https://api.github.com/repos/${repoName}`, {
+  const request = await fetchWithRetries(`https://api.github.com/repos/${repoName}`, {
     method: 'GET',
     headers: header,
   }).catch(error => logger.error('Error in fetch REST API:', error));
-
-  const content = await request.json();
-  return content.stargazers_count;
+  // avoid situations where the project is empty
+  try {
+    const content = await request.json();
+    return content.stargazers_count;
+  } catch (error) {
+    logger.error('The project is empty:', error);
+    return null;
+  }
 }
 
 export async function projectHistoryTimer() {

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -38,6 +38,7 @@ async function getProjectList(projectId) {
 }
 
 async function getExistRecord() {
+  const currentDate = new Date();
   const existRecordList = await GithubProjectsHistory.findAll({
     where: {
       contributors: {
@@ -46,9 +47,7 @@ async function getExistRecord() {
       stars: {
         [Op.ne]: null,
       },
-      date: {
-        [Op.eq]: sequelize.fn('CURDATE'),
-      },
+      date: currentDate,
     },
   }).catch(err => {
     logger.error('Error in query: ', err);

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -37,7 +37,9 @@ async function getProjectList(projectId) {
 
 async function getExistRecord() {
   const existRecordList = await GithubProjectsHistory.findAll({
-    where: sequelize.literal('DATE(Date) = CURDATE()'),
+    where: sequelize.literal(
+      'DATE(Date) = CURDATE() AND contributors IS NOT NULL and stars IS NOT NULL',
+    ),
   }).catch(err => {
     logger.error('Error in query: ', err);
   });
@@ -53,7 +55,6 @@ export default async function syncProjectHistory(projectId) {
   let count = 1;
   // 2. get the exist record
   const existRecordList = await getExistRecord();
-  logger.info(existRecordList);
   for (const project of projectList) {
     logger.info('**Current Progress**: ', `${count}/${sumOfProject}`);
     count += 1;

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -35,6 +35,15 @@ async function getProjectList(projectId) {
   return projectList;
 }
 
+async function getExistRecord() {
+  const existRecordList = await GithubProjectsHistory.findAll({
+    where: sequelize.literal('DATE(Date) = CURDATE()'),
+  }).catch(err => {
+    logger.error('Error in query: ', err);
+  });
+  return existRecordList;
+}
+
 export default async function syncProjectHistory(projectId) {
   logger.info('Sync Project Contributors');
   // 1. get all github project
@@ -42,10 +51,21 @@ export default async function syncProjectHistory(projectId) {
   const sumOfProject = projectList.length;
   logger.info(`The Number of Project : ${sumOfProject}`);
   let count = 1;
+  // 2. get the exist record
+  const existRecordList = await getExistRecord();
+  logger.info(existRecordList);
   for (const project of projectList) {
     logger.info('**Current Progress**: ', `${count}/${sumOfProject}`);
     count += 1;
-    // 2. get project information
+    // 3. determine whether integration is required
+    if (existRecordList) {
+      const existData = existRecordList.find(item => item.projectId === project.id);
+      if (existData) {
+        logger.info('Record already exists, ignore this project.');
+        continue;
+      }
+    }
+    // 4. get project information
     let [contributors, stars] = await getProjectInformation(project.htmlUrl);
     // check contributors
     if (!contributors) {
@@ -148,7 +168,7 @@ async function getStars(repoName) {
   const request = await fetch(`https://api.github.com/repos/${repoName}`, {
     method: 'GET',
     headers: header,
-  });
+  }).catch(error => logger.error('Error in fetch REST API:', error));
 
   const content = await request.json();
   return content.stargazers_count;

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -2,7 +2,6 @@ import {
   GithubProjects,
   GithubProjectsHistory,
   GithubProjectsTable,
-  sequelize,
   logger,
 } from '@orginjs/oss-evaluation-data-model';
 import { getProjectByUrl } from '../util/util.js';
@@ -100,7 +99,7 @@ export default async function syncProjectHistory(projectId) {
       },
     );
     // store github_projects_history
-    const currentDate = sequelize.literal('CURDATE()');
+    const currentDate = new Date();
     await GithubProjectsHistory.upsert(
       {
         projectId: project.id,

--- a/packages/integration/controllers/trendHistory.js
+++ b/packages/integration/controllers/trendHistory.js
@@ -153,55 +153,41 @@ async function getMonthData(dataList) {
 }
 
 /**
- * Calculate the increase and total amount by month
+ * Get data for the January of current year and January of last year
  *
- * @param {*} monthDataField
- * @param {*} field
- * @param {*} currentMonthData
- * @param {*} lastMonthData
+ * @param {*} dataList
+ * @return {*}
  */
-async function initializeMonthData(monthDataField, field, currentMonthData, lastMonthData) {
-  if (currentMonthData) {
-    monthDataField.current = currentMonthData[field];
-  }
-  if (lastMonthData) {
-    monthDataField.last = lastMonthData[field];
-  }
-  if (monthDataField.current && monthDataField.last) {
-    monthDataField.increase = monthDataField.current - monthDataField.last;
-  }
+async function getYearData(dataList) {
+  const currentYear = dayjs().year();
+  const lastYear = currentYear - 1;
+  const currentYearData = dataList.find(
+    item =>
+      new Date(item.date).getMonth() === 0 && new Date(item.date).getFullYear() === currentYear,
+  );
+  const lastYearData = dataList.find(
+    item => new Date(item.date).getMonth() === 0 && new Date(item.date).getFullYear() === lastYear,
+  );
+  return [currentYearData, lastYearData];
 }
 
 /**
- * Calculate the increase and total amount by year
+ * Calculate the increase and current amount
  *
- * @param {*} yearDataField
+ * @param {*} dataField
  * @param {*} field
- * @param {*} dataList
+ * @param {*} currentData
+ * @param {*} lastData
  */
-async function initializeYearData(yearDataField, field, dataList) {
-  const currentYear = dayjs().year();
-  dataList.forEach(item => {
-    const date = new Date(item.date);
-    const year = date.getFullYear();
-    if (year === currentYear) {
-      if (item[field]) {
-        if (!yearDataField.current) {
-          yearDataField.current = 0;
-        }
-        yearDataField.current += item[field];
-      }
-    } else if (year === currentYear - 1) {
-      if (item[field]) {
-        if (!yearDataField.last) {
-          yearDataField.last = 0;
-        }
-        yearDataField.last += item[field];
-      }
-    }
-  });
-  if (yearDataField.current && yearDataField.last) {
-    yearDataField.increase = yearDataField.current - yearDataField.last;
+async function initializeData(dataField, field, currentData, lastData) {
+  if (currentData) {
+    dataField.current = currentData[field];
+  }
+  if (lastData) {
+    dataField.last = lastData[field];
+  }
+  if (dataField.current && dataField.last) {
+    dataField.increase = dataField.current - dataField.last;
   }
 }
 
@@ -235,7 +221,7 @@ async function getDumpQuery(projectId, data, dataType, dateType) {
   return [insertedData, condition];
 }
 
-async function dumpGithubHistoryTable(projectId, monthData, yearData) {
+async function dumpGithubHistoryMonthTable(projectId, monthData) {
   // 存入月相关数据
   const queryStarMonth = await getDumpQuery(
     projectId,
@@ -251,6 +237,9 @@ async function dumpGithubHistoryTable(projectId, monthData, yearData) {
   );
   await TrendHistory.upsert(queryStarMonth[0], queryStarMonth[1]);
   await TrendHistory.upsert(queryContributorMonth[0], queryContributorMonth[1]);
+}
+
+async function dumpGithubHistoryYearTable(projectId, yearData) {
   // 存入年相关数据
   const queryStarYear = await getDumpQuery(
     projectId,
@@ -268,7 +257,7 @@ async function dumpGithubHistoryTable(projectId, monthData, yearData) {
   await TrendHistory.upsert(queryContributorYear[0], queryContributorYear[1]);
 }
 
-async function dumpEvaluateHistoryTable(projectId, monthData, yearData) {
+async function dumpEvaluateHistoryTable(projectId, monthData) {
   // 存入月相关数据
   const queryEcologyMonth = await getDumpQuery(
     projectId,
@@ -284,21 +273,6 @@ async function dumpEvaluateHistoryTable(projectId, monthData, yearData) {
   );
   await TrendHistory.upsert(queryEcologyMonth[0], queryEcologyMonth[1]);
   await TrendHistory.upsert(queryQualityMonth[0], queryQualityMonth[1]);
-  // 存入年相关数据
-  const queryEcologyYear = await getDumpQuery(
-    projectId,
-    yearData.ecology,
-    DATA_TYPE.ECOLOGY,
-    DATE_TYPE.YEAR,
-  );
-  const queryQualityYear = await getDumpQuery(
-    projectId,
-    yearData.quality,
-    DATA_TYPE.QUALITY,
-    DATE_TYPE.YEAR,
-  );
-  await TrendHistory.upsert(queryEcologyYear[0], queryEcologyYear[1]);
-  await TrendHistory.upsert(queryQualityYear[0], queryQualityYear[1]);
 }
 
 export async function storeGithubHistory(projectId) {
@@ -309,7 +283,6 @@ export async function storeGithubHistory(projectId) {
   const monthRawData = await getMonthData(githubHistoryList);
   const currentMonthData = monthRawData[0];
   const lastMonthData = monthRawData[1];
-
   // 当月总量和增长量
   const monthData = {
     star: {
@@ -323,9 +296,20 @@ export async function storeGithubHistory(projectId) {
       increase: null,
     },
   };
-  await initializeMonthData(monthData.star, 'stars', currentMonthData, lastMonthData);
-  await initializeMonthData(monthData.contributor, 'contributors', currentMonthData, lastMonthData);
+  await initializeData(monthData.star, 'stars', currentMonthData, lastMonthData);
+  await initializeData(monthData.contributor, 'contributors', currentMonthData, lastMonthData);
+  // 存入数据表
+  await dumpGithubHistoryMonthTable(projectId, monthData);
 
+  const currentMonth = dayjs().month();
+  // 仅在1月计算年相关数据
+  if (currentMonth !== 0) {
+    return;
+  }
+  // 当年和上年数据
+  const yearRawData = await getYearData(githubHistoryList);
+  const currentYearData = yearRawData[0];
+  const lastYearData = yearRawData[1];
   // 当年总量和增长量
   const yearData = {
     star: {
@@ -339,10 +323,10 @@ export async function storeGithubHistory(projectId) {
       increase: null,
     },
   };
-  await initializeYearData(yearData.star, 'stars', githubHistoryList);
-  await initializeYearData(yearData.contributor, 'contributors', githubHistoryList);
+  await initializeData(yearData.star, 'stars', currentYearData, lastYearData);
+  await initializeData(yearData.contributor, 'contributors', currentYearData, lastYearData);
   // 存入数据表
-  await dumpGithubHistoryTable(projectId, monthData, yearData);
+  await dumpGithubHistoryYearTable(projectId, yearData);
 }
 
 export async function storeEvaluateScore(projectId) {
@@ -367,24 +351,9 @@ export async function storeEvaluateScore(projectId) {
       increase: null,
     },
   };
-  await initializeMonthData(monthData.ecology, 'ecologyScore', currentMonthData, lastMonthData);
-  await initializeMonthData(monthData.quality, 'qualityScore', currentMonthData, lastMonthData);
+  await initializeData(monthData.ecology, 'ecologyScore', currentMonthData, lastMonthData);
+  await initializeData(monthData.quality, 'qualityScore', currentMonthData, lastMonthData);
 
-  // 当年总量和增长量
-  const yearData = {
-    ecology: {
-      current: null,
-      last: null,
-      increase: null,
-    },
-    quality: {
-      current: null,
-      last: null,
-      increase: null,
-    },
-  };
-  await initializeYearData(yearData.ecology, 'ecologyScore', evaluationHistoryList);
-  await initializeYearData(yearData.quality, 'qualityScore', evaluationHistoryList);
   // 存入数据表
-  await dumpEvaluateHistoryTable(projectId, monthData, yearData);
+  await dumpEvaluateHistoryTable(projectId, monthData);
 }

--- a/packages/integration/controllers/trendHistory.js
+++ b/packages/integration/controllers/trendHistory.js
@@ -3,7 +3,6 @@ import {
   GithubProjectsHistory,
   EvaluationSummaryHistory,
   TrendHistory,
-  sequelize,
   logger,
 } from '@orginjs/oss-evaluation-data-model';
 import { getProjectByUrl } from '../util/util.js';
@@ -201,7 +200,7 @@ async function initializeData(dataField, field, currentData, lastData) {
  * @return {*}
  */
 async function getDumpQuery(projectId, data, dataType, dateType) {
-  const currentDate = sequelize.literal('CURDATE()');
+  const currentDate = new Date();
   const insertedData = {
     projectId: projectId,
     date: currentDate,

--- a/packages/integration/util/fetchWithRetries.js
+++ b/packages/integration/util/fetchWithRetries.js
@@ -1,0 +1,25 @@
+import { logger } from '@orginjs/oss-evaluation-data-model';
+
+export async function fetchWithRetries(url, options = {}, attempts = 3) {
+  if (typeof options === 'number') {
+    attempts = options;
+    options = {};
+  }
+  try {
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+
+    return response;
+  } catch (error) {
+    logger.error('Error fetching data:', error);
+    if (attempts > 0) {
+      logger.info(`Retrying... Attempts left: ${attempts}`);
+      return fetchWithRetries(url, options, attempts - 1);
+    } else {
+      throw new Error('Max retry attempts exceeded');
+    }
+  }
+}

--- a/packages/integration/util/fetchWithRetries.js
+++ b/packages/integration/util/fetchWithRetries.js
@@ -1,25 +1,28 @@
 import { logger } from '@orginjs/oss-evaluation-data-model';
+import { sleep } from './util.js';
 
 export async function fetchWithRetries(url, options = {}, attempts = 3) {
   if (typeof options === 'number') {
     attempts = options;
     options = {};
   }
-  try {
-    const response = await fetch(url, options);
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const response = await fetch(url, options);
 
-    if (!response.ok) {
-      throw new Error('Network response was not ok');
-    }
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
 
-    return response;
-  } catch (error) {
-    logger.error('Error fetching data:', error);
-    if (attempts > 0) {
-      logger.info(`Retrying... Attempts left: ${attempts}`);
-      return fetchWithRetries(url, options, attempts - 1);
-    } else {
-      throw new Error('Max retry attempts exceeded');
+      return response;
+    } catch (error) {
+      logger.error('Error fetching data:', error);
+      if (i < attempts - 1) {
+        await sleep(5000);
+        logger.info(`Retrying... Attempts: ${i + 1}`);
+      } else {
+        throw new Error('Max retry attempts exceeded');
+      }
     }
   }
 }


### PR DESCRIPTION
1. 删除了生态评分、质量评分的年度数据计算逻辑（该类数据意义不大）
2. 修改了star、contributor的年度数据计算逻辑（增长量：今年1月-去年1月，总量：今年1月），且仅在1月份执行（减轻数据表的长度压力）
3. 对使用REST API时出现的异常情况进行了处理（若请求失败，重新请求，最多三次）
4. 集成githubHistory数据时，跳过已存在的记录（若stars或contributors为空则不跳过）
5. 存取数据时统一改为系统时间而不是数据库时间
6. 将evaluate-summary-history中原生SQL改为结构化查询