### PR TITLE
feat: detect emerging projects and integrate them into github_projects_t

### DIFF
--- a/packages/integration/controllers/github.js
+++ b/packages/integration/controllers/github.js
@@ -3,6 +3,8 @@ import * as fs from 'node:fs';
 import { Octokit } from '@octokit/core';
 import { GithubProjectsTable, logger } from '@orginjs/oss-evaluation-data-model';
 import GithubSdk from '@orginjs/github-sdk';
+import { fetchWithRetries } from '../util/fetchWithRetries.js';
+import * as cheerio from 'cheerio';
 
 /**
  *  There are 952 github projects between 1000 and 1130 stars.
@@ -28,6 +30,12 @@ const dataTypes = {
   hiddenRepo: 4,
   // Newly integrated github repository, but no other statistics yet
   needIntegration: 9,
+};
+
+const periodTypes = {
+  day: 'daily',
+  week: 'weekly',
+  month: 'mongthly',
 };
 
 export async function observeProjectsByStar(req, res) {
@@ -346,4 +354,170 @@ function parseLinks(linksStr) {
     links[key] = value;
   });
   return links;
+}
+
+async function getGithubTrendProjects(period = periodTypes.day) {
+  let projectsList = [];
+
+  const url = `https://github.com/trending?since=${period}&spoken_language_code=`;
+  const response = await fetchWithRetries(url);
+  if (!response) {
+    logger.info('The network is faulty and the github projects trending list cannot be obtained');
+    return projectsList;
+  }
+
+  const content = await response.text();
+  const $ = cheerio.load(content);
+
+  // get the project list
+  $('article.Box-row').each((index, element) => {
+    const h2Element = $(element).find('h2.h3.lh-condensed');
+    const aElement = h2Element.find('a');
+
+    if (aElement.length > 0) {
+      const href = aElement.attr('href');
+      const project = href.substring(1);
+      projectsList.push(project);
+    } else {
+      logger.info('project name not found');
+    }
+  });
+
+  return projectsList;
+}
+
+async function getOssTrendProjects() {
+  let projectsList = [];
+
+  // get the daily oss trend projects
+  const url = `https://api.ossinsight.io/v1/trends/repos/`;
+  const response = await fetchWithRetries(url);
+  if (!response) {
+    logger.info('The network is faulty and the oss trending list cannot be obtained');
+    return projectsList;
+  }
+  const content = await response.json();
+  for (const project of content.data.rows) {
+    projectsList.push(project.repo_name);
+  }
+
+  return projectsList;
+}
+
+async function getOssCollectionProjects() {
+  let projectsList = [];
+  let collectionList = [];
+
+  // get the oss collection ids
+  const url = `https://api.ossinsight.io/v1/collections/`;
+  const response = await fetchWithRetries(url);
+  if (!response) {
+    logger.info('The network is faulty and the oss collection list cannot be obtained');
+    return projectsList;
+  }
+  const content = await response.json();
+  for (const collection of content.data.rows) {
+    collectionList.push(collection.id);
+  }
+
+  // using collection id to get the oss star trend projects, which is the most complete list
+  for (const collectionId of collectionList) {
+    const collectionUrl = `https://api.ossinsight.io/v1/collections/${collectionId}/ranking_by_stars/`;
+    const collectionResponse = await fetch(collectionUrl);
+    if (!collectionResponse) {
+      logger.info(
+        `The network is faulty and the projects list of oss collection ${collectionId} cannot be obtained`,
+      );
+      continue;
+    }
+    const collectionContent = await collectionResponse.json();
+    for (const collection of collectionContent.data.rows) {
+      projectsList.push(collection.repo_name);
+    }
+  }
+
+  return projectsList;
+}
+
+async function mergeAndRemoveDuplicates(...arrays) {
+  let mergedArray = [].concat(...arrays);
+  let uniqueArray = Array.from(new Set(mergedArray));
+  return uniqueArray;
+}
+
+async function syncGithubProjects(projectList) {
+  const existProjectsList = await GithubProjectsTable.findAll({
+    attributes: ['fullName'],
+  });
+
+  for (const project of projectList) {
+    const existData = existProjectsList.find(item => item.fullName === project);
+    if (existData) {
+      logger.info('Record already exists, ignore this project.');
+      continue;
+    }
+    const options = {
+      url: `https://github.com/${project}`,
+    };
+    await syncSingleGithubProject(options);
+  }
+}
+
+/**
+ * Daily integration of github daily trends and oss trends
+ *
+ */
+async function syncGithubProjectsDaily() {
+  const githubDailyTrendList = await getGithubTrendProjects(periodTypes.day);
+  const ossTrendList = await getOssTrendProjects();
+  const projectsList = await mergeAndRemoveDuplicates(githubDailyTrendList, ossTrendList);
+  await syncGithubProjects(projectsList);
+}
+
+/**
+ * Weekly integration of github weekly trends, github monthly trends and oss collection trends
+ *
+ */
+async function syncGithubProjectsWeekly() {
+  const githubWeeklyTrendList = await getGithubTrendProjects(periodTypes.week);
+  const githubMonthlyTrendList = await getGithubTrendProjects(periodTypes.month);
+  const ossCollectionTrendList = await getOssCollectionProjects();
+  const projectsList = await mergeAndRemoveDuplicates(
+    githubWeeklyTrendList,
+    githubMonthlyTrendList,
+    ossCollectionTrendList,
+  );
+  await syncGithubProjects(projectsList);
+}
+
+export async function syncGithubProjectsDailyHandler(req, res) {
+  await syncGithubProjectsDaily();
+  res.status(200).send('success');
+}
+
+export async function syncGithubProjectsWeeklyHandler(req, res) {
+  await syncGithubProjectsWeekly();
+  res.status(200).send('success');
+}
+
+export async function githubProjectsDailyTimer() {
+  const startTime = process.hrtime();
+  logger.info('[Integration][GithubProjectsDaily] Integration Job start');
+  await syncGithubProjectsDaily();
+  logger.info('[Integration][GithubProjectsDaily] Integration Job end');
+  const endTime = process.hrtime(startTime);
+  logger.info(
+    `[Integration][GithubProjectsDaily] The total time spent on integration : ${endTime[0]}s ${endTime[1] / 1e6}ms`,
+  );
+}
+
+export async function githubProjectsWeeklyTimer() {
+  const startTime = process.hrtime();
+  logger.info('[Integration][GithubProjectsWeekly] Integration Job start');
+  await syncGithubProjectsWeekly();
+  logger.info('[Integration][GithubProjectsWeekly] Integration Job end');
+  const endTime = process.hrtime(startTime);
+  logger.info(
+    `[Integration][GithubProjectsWeekly] The total time spent on integration : ${endTime[0]}s ${endTime[1] / 1e6}ms`,
+  );
 }

--- a/packages/integration/controllers/github.js
+++ b/packages/integration/controllers/github.js
@@ -453,7 +453,6 @@ async function syncGithubProjects(projectList) {
   for (const project of projectList) {
     const existData = existProjectsList.find(item => item.fullName === project);
     if (existData) {
-      logger.info('Record already exists, ignore this project.');
       continue;
     }
     const options = {

--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -110,10 +110,11 @@ async function getProjectContributors(url) {
 }
 
 async function getContributors(repoName, page = 1) {
-  const header = process.env.GITHUB_TOKEN
+  const tokens = JSON.parse(process.env.GITHUB_TOKEN);
+  const header = tokens
     ? {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+        Authorization: `Bearer ${tokens[0]}`,
       }
     : {
         'Content-Type': 'application/json',

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -35,8 +35,7 @@ async function getProjectList(projectId) {
   return projectList;
 }
 
-async function getExistRecord() {
-  const currentDate = new Date();
+async function getExistRecord(currentDate) {
   const existRecordList = await GithubProjectsHistory.findAll({
     where: {
       contributors: {
@@ -53,7 +52,7 @@ async function getExistRecord() {
   return existRecordList;
 }
 
-export async function syncHistoryByProjectList(projectList) {
+export async function syncHistoryByProjectList(projectList, currentDate) {
   const sumOfProject = projectList.length;
   logger.info(`The Number of Project : ${sumOfProject}`);
   let count = 1;
@@ -85,7 +84,6 @@ export async function syncHistoryByProjectList(projectList) {
       },
     );
     // store github_projects_history
-    const currentDate = new Date();
     await GithubProjectsHistory.upsert(
       {
         projectId: project.id,
@@ -104,9 +102,9 @@ export async function syncHistoryByProjectList(projectList) {
   }
 }
 
-async function filterExistProject(projectId) {
+async function filterExistProject(projectId, currentDate) {
   const allProjectList = await getProjectList(projectId);
-  const existRecordList = await getExistRecord();
+  const existRecordList = await getExistRecord(currentDate);
   const projectList = allProjectList.filter(
     project => !existRecordList.some(existProject => existProject.id === project.id),
   );
@@ -114,11 +112,12 @@ async function filterExistProject(projectId) {
 }
 
 export default async function syncProjectHistory(projectId) {
+  const currentDate = new Date();
   for (let tryTimes = 0; tryTimes < 5; tryTimes++) {
     logger.info(`Sync Project History......Try Time: ${tryTimes + 1}`);
-    const projectList = filterExistProject(projectId);
+    const projectList = await filterExistProject(projectId, currentDate);
     if (projectList.length > 0) {
-      await syncHistoryByProjectList(projectList);
+      await syncHistoryByProjectList(projectList, currentDate);
     } else {
       return;
     }

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -4,8 +4,7 @@ import {
   GithubProjectsTable,
   logger,
 } from '@orginjs/oss-evaluation-data-model';
-import { getProjectByUrl } from '../util/util.js';
-import { fetchWithTimeout } from '../util/fetchWitTimeout.js';
+import { getProjectByUrl, sleep } from '../util/util.js';
 import { fetchWithRetries } from '../util/fetchWithRetries.js';
 import { getAlllContributors } from './projectContributors.js';
 import * as cheerio from 'cheerio';
@@ -54,27 +53,14 @@ async function getExistRecord() {
   return existRecordList;
 }
 
-export default async function syncProjectHistory(projectId) {
-  logger.info('Sync Project Contributors');
-  // 1. get all github project
-  const projectList = await getProjectList(projectId);
+export async function syncHistoryByProjectList(projectList) {
   const sumOfProject = projectList.length;
   logger.info(`The Number of Project : ${sumOfProject}`);
   let count = 1;
-  // 2. get the exist record
-  const existRecordList = await getExistRecord();
   for (const project of projectList) {
     logger.info('**Current Progress**: ', `${count}/${sumOfProject}`);
     count += 1;
-    // 3. determine whether integration is required
-    const existData = existRecordList
-      ? existRecordList.find(item => item.projectId === project.id)
-      : null;
-    if (existData) {
-      logger.info('Record already exists, ignore this project.');
-      continue;
-    }
-    // 4. get project information
+    // get project information
     let [contributors, stars] = await getProjectInformation(project.htmlUrl);
     // check contributors
     if (!contributors) {
@@ -118,10 +104,32 @@ export default async function syncProjectHistory(projectId) {
   }
 }
 
+async function filterExistProject(projectId) {
+  const allProjectList = await getProjectList(projectId);
+  const existRecordList = await getExistRecord();
+  const projectList = allProjectList.filter(
+    project => !existRecordList.some(existProject => existProject.id === project.id),
+  );
+  return projectList;
+}
+
+export default async function syncProjectHistory(projectId) {
+  for (let tryTimes = 0; tryTimes < 5; tryTimes++) {
+    logger.info(`Sync Project History......Try Time: ${tryTimes + 1}`);
+    const projectList = filterExistProject(projectId);
+    if (projectList.length > 0) {
+      await syncHistoryByProjectList(projectList);
+    } else {
+      return;
+    }
+    await sleep(3600 * 1000);
+  }
+}
+
 async function getProjectInformation(url) {
   let contributors, stars;
   try {
-    const response = await fetchWithTimeout(url, 3 * 60 * 1000);
+    const response = await fetchWithRetries(url);
     if (response.ok) {
       const text = await response.text();
       // parse html

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -165,10 +165,11 @@ async function getProjectInformation(url) {
 }
 
 async function getStars(repoName) {
-  const header = process.env.GITHUB_TOKEN
+  const tokens = JSON.parse(process.env.GITHUB_TOKEN);
+  const header = tokens
     ? {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+        Authorization: `Bearer ${tokens[0]}`,
       }
     : {
         'Content-Type': 'application/json',

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -102,7 +102,7 @@ export async function syncHistoryByProjectList(projectList, currentDate) {
   }
 }
 
-async function filterExistProject(projectId, currentDate) {
+async function filterNotExistProject(projectId, currentDate) {
   const allProjectList = await getProjectList(projectId);
   const existRecordList = await getExistRecord(currentDate);
   const projectList = allProjectList.filter(
@@ -115,7 +115,7 @@ export default async function syncProjectHistory(projectId) {
   const currentDate = new Date();
   for (let tryTimes = 0; tryTimes < 5; tryTimes++) {
     logger.info(`Sync Project History......Try Time: ${tryTimes + 1}`);
-    const projectList = await filterExistProject(projectId, currentDate);
+    const projectList = await filterNotExistProject(projectId, currentDate);
     if (projectList.length > 0) {
       await syncHistoryByProjectList(projectList, currentDate);
     } else {

--- a/packages/integration/routes/sync.js
+++ b/packages/integration/routes/sync.js
@@ -27,6 +27,8 @@ import {
   syncProjectByRepo,
   syncProjectByUserStar,
   searchAndIntegrationGithubProjects,
+  syncGithubProjectsDailyHandler,
+  syncGithubProjectsWeeklyHandler,
 } from '../controllers/github.js';
 import {
   bulkAddBenchmarkHandler,
@@ -1447,5 +1449,27 @@ router.route('/storeAllProjectTrend').get(storeAllProjectTrendHandler);
  *         description: success.
  */
 router.route('/storeSingleProjectTrend/:repoUrl').get(storeSingleProjectTrendHandler);
+
+/**
+ * @swagger
+ * /sync/syncGithubProjectsDaily:
+ *   get:
+ *     summary: integration of github daily trends and oss trends
+ *     responses:
+ *       200:
+ *         description: success.
+ */
+router.route('/syncGithubProjectsDaily').get(syncGithubProjectsDailyHandler);
+
+/**
+ * @swagger
+ * /sync/syncGithubProjectsWeekly:
+ *   get:
+ *     summary: integration of github weekly trends, github monthly trends and oss collection trends
+ *     responses:
+ *       200:
+ *         description: success.
+ */
+router.route('/syncGithubProjectsWeekly').get(syncGithubProjectsWeeklyHandler);
 
 export default router;

--- a/packages/integration/scheduler/config.js
+++ b/packages/integration/scheduler/config.js
@@ -43,5 +43,15 @@ export const JobConfig = {
       cronScheduleTime: '0 0 1 * *', // 每月1号 00:00
       enabled: isProduction, // only start in production environment
     },
+    {
+      name: 'githubProjectsDailyTimer',
+      cronScheduleTime: '0 0 * * *', // 每天 00:00
+      enabled: isProduction, // only start in production environment
+    },
+    {
+      name: 'githubProjectsWeeklyTimer',
+      cronScheduleTime: '0 0 * * 1', // 周一 00:00
+      enabled: isProduction, // only start in production environment
+    },
   ],
 };

--- a/packages/integration/scheduler/job.js
+++ b/packages/integration/scheduler/job.js
@@ -9,6 +9,7 @@ import { projectCodeSizeTimer } from '../controllers/projectCodeSize.js';
 import { projectContributorsTimer } from '../controllers/projectContributors.js';
 import { evaluateTimer } from '../controllers/evaluate.js';
 import { projectHistoryTimer } from '../controllers/projectHistory.js';
+import { githubProjectsDailyTimer, githubProjectsWeeklyTimer } from '../controllers/github.js';
 
 function createTimer(name, pattern, timer) {
   if (!pattern) {
@@ -41,6 +42,8 @@ const taskFactory = {
   projectContributorsTimer,
   evaluateTimer,
   projectHistoryTimer,
+  githubProjectsDailyTimer,
+  githubProjectsWeeklyTimer,
   createTask: function (taskName) {
     if (!this[taskName]) {
       throw new Error(`Task ${taskName} not found`);


### PR DESCRIPTION
1. 新功能：从github趋势榜、oss趋势榜获取新兴项目加入github_projects_t表中（已存在则忽略）。
   - github趋势榜包括日榜、周榜、月榜。
   - oss趋势榜包括总榜和各集合榜单。
      - 请求oss各集合中包含的项目最多返回50个项目，请求oss各集合的ranking仓库最多返回1000个项目，其中star ranking是最完整的，故仅通过oss的star ranking来获取各集合的新兴项目。
3. 设置定时器：
   - 每天0点从 github趋势日榜、oss趋势近24小时榜 集成项目。
   - 每周一0点从 github趋势周榜、github趋势月榜、oss各集合的趋势月榜 集成项目。
4. 统一了趋势榜单二相关数据集成的token使用方式。
5. github历史信息集成时，集成失败的项目将会统一进行重试，最多重试4次，间隔一小时。
6. 信息集成时统一为任务开始的时间，防止同一批数据的存入日期不同。
