### PR TITLE
fix: contributor API is called only if the GitHub page does not provide contributor information

### DIFF
--- a/packages/integration/controllers/projectContributors.js
+++ b/packages/integration/controllers/projectContributors.js
@@ -54,7 +54,7 @@ export default async function syncProjectContributors(projectId) {
     // 2. get project contributors
     let contributors = await getProjectContributors(project.htmlUrl);
     if (contributors == '' || contributors == undefined) {
-      contributors = (await getAlllContributors(project.fullName)).length;
+      contributors = await getAlllContributors(project.fullName);
       logger.info(`GitHub API : contributors of ${project.htmlUrl} is ${contributors}`);
     }
     if (contributors == '' || contributors == undefined) {
@@ -62,7 +62,7 @@ export default async function syncProjectContributors(projectId) {
     }
 
     await GithubProjectsTable.update(
-      { contributors: contributors },
+      { contributors: contributors === -1 ? null : contributors },
       {
         where: {
           id: project.id,
@@ -126,7 +126,10 @@ async function getContributors(repoName, page = 1) {
       method: 'GET',
       headers: header,
     },
-  ).catch(error => logger.error('Error in fetch REST API:', error));
+  ).catch(error => {
+    logger.error('Error in fetch REST API:', error);
+    return -1;
+  });
   // avoid situations where the project is empty
   try {
     return await request.json();
@@ -142,6 +145,10 @@ export async function getAlllContributors(repoName) {
   let list;
   do {
     list = await getContributors(repoName, page);
+    // fetch API failed
+    if (typeof list === 'number') {
+      return -1;
+    }
     contributors = contributors.concat(list);
     page++;
   } while (list.length > 0);
@@ -150,7 +157,7 @@ export async function getAlllContributors(repoName) {
       contributors.splice(i, 1);
     }
   }
-  return contributors;
+  return contributors.length;
 }
 
 export async function projectContributorsTimer() {

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -63,8 +63,7 @@ export async function syncHistoryByProjectList(projectList, currentDate) {
     let [contributors, stars] = await getProjectInformation(project.htmlUrl);
     // API is called only if the GitHub page does not provide contributor information
     if (contributors === -1) {
-      const contributorsByApi = (await getAlllContributors(project.fullName)).length;
-      contributors = contributorsByApi ? contributorsByApi : null;
+      contributors = await getAlllContributors(project.fullName);
     }
     if (contributors) {
       logger.info(`GitHub API : contributors of ${project.htmlUrl} is ${contributors}`);
@@ -81,7 +80,7 @@ export async function syncHistoryByProjectList(projectList, currentDate) {
     }
     // refresh github_projects_t
     await GithubProjectsTable.update(
-      { contributors: contributors },
+      { contributors: contributors === -1 ? null : contributors },
       {
         where: {
           id: project.id,
@@ -93,7 +92,7 @@ export async function syncHistoryByProjectList(projectList, currentDate) {
       {
         projectId: project.id,
         date: currentDate,
-        contributors: contributors,
+        contributors: contributors === -1 ? null : contributors,
         stars: stars,
       },
       {

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -61,8 +61,8 @@ export async function syncHistoryByProjectList(projectList, currentDate) {
     count += 1;
     // get project information
     let [contributors, stars] = await getProjectInformation(project.htmlUrl);
-    // check contributors
-    if (!contributors) {
+    // API is called only if the GitHub page does not provide contributor information
+    if (contributors === -1) {
       contributors = (await getAlllContributors(project.fullName)).length;
       logger.info(`GitHub API : contributors of ${project.htmlUrl} is ${contributors}`);
     }
@@ -138,6 +138,7 @@ async function getProjectInformation(url) {
       const content = $(`a[href="/${repoName}/graphs/contributors"]`).text();
       if (content.length === 0) {
         logger.info(`web crawler: ${url} does not provide contributors...`);
+        contributors = -1;
       } else {
         const regex = /(\d{1,3}(,\d{3})*(\.\d+)?)/g;
         const contributorsArrays = content.match(regex);

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -63,12 +63,17 @@ export async function syncHistoryByProjectList(projectList, currentDate) {
     let [contributors, stars] = await getProjectInformation(project.htmlUrl);
     // API is called only if the GitHub page does not provide contributor information
     if (contributors === -1) {
-      contributors = (await getAlllContributors(project.fullName)).length;
+      const contributorsByApi = (await getAlllContributors(project.fullName)).length;
+      contributors = contributorsByApi ? contributorsByApi : null;
+    }
+    if (contributors) {
       logger.info(`GitHub API : contributors of ${project.htmlUrl} is ${contributors}`);
     }
     // check stars
     if (!stars) {
       stars = await getStars(project.fullName);
+    }
+    if (stars) {
       logger.info(`GitHub API : stars of ${project.htmlUrl} is ${stars}`);
     }
     if (!contributors && !stars) {

--- a/packages/integration/controllers/projectHistory.js
+++ b/packages/integration/controllers/projectHistory.js
@@ -93,8 +93,8 @@ export async function syncHistoryByProjectList(projectList, currentDate) {
       {
         projectId: project.id,
         date: currentDate,
-        contributors: contributors ? contributors : 0,
-        stars: stars ? stars : 0,
+        contributors: contributors,
+        stars: stars,
       },
       {
         where: {
@@ -111,7 +111,7 @@ async function filterNotExistProject(projectId, currentDate) {
   const allProjectList = await getProjectList(projectId);
   const existRecordList = await getExistRecord(currentDate);
   const projectList = allProjectList.filter(
-    project => !existRecordList.some(existProject => existProject.id === project.id),
+    project => !existRecordList.some(existProject => existProject.projectId === project.id),
   );
   return projectList;
 }


### PR DESCRIPTION
1. 仅当GitHub页面不提供contributor数量时再调用API获取，以避免API提供的数量与GitHub页面不一致导致的负增长问题。
2. 当API返回contributor数量为0时，将存入表中的contributor数量设为null。
   - 项目为空时API返回contributor数量为0，此时应该设为null；
   - API请求失败时返回的contributor数量为0，此时设为null可在下一轮重试时重新请求。
3. 修复了过滤未记录项目时project_id列选择错误的bug，该bug导致无法正常过滤。
