### PR TITLE
feat: add table trend_rank_history to create baseline ranking data

### DIFF
--- a/packages/data-model/index.js
+++ b/packages/data-model/index.js
@@ -36,4 +36,5 @@ export { default as OssinsightCreatorsOrganizations } from './models/OssinsightC
 export { default as OssinsightCreatorsCountries } from './models/OssinsightCreatorsCountries.js';
 export { default as GithubProjectsRank } from './models/GithubProjectsRank.js';
 export { default as TrendHistory } from './models/TrendHistory.js';
+export { default as TrendRankHistory } from './models/TrendRankHistory.js';
 export { default as NewProjectApply } from './models/NewProjectApply.js';

--- a/packages/data-model/models/TrendRankHistory.js
+++ b/packages/data-model/models/TrendRankHistory.js
@@ -1,0 +1,42 @@
+import { DataTypes } from 'sequelize';
+import sequelize from '../util/database.js';
+
+export default sequelize.define(
+  'TrendRankHistory',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    projectId: {
+      type: DataTypes.INTEGER,
+    },
+    dataType: {
+      type: DataTypes.INTEGER,
+    },
+    increasedValue: {
+      type: DataTypes.DOUBLE,
+    },
+    totalValue: {
+      type: DataTypes.DOUBLE,
+    },
+    dateType: {
+      type: DataTypes.INTEGER,
+    },
+    date: {
+      type: DataTypes.DATEONLY,
+    },
+    rankType: {
+      type: DataTypes.INTEGER,
+    },
+    rank: {
+      type: DataTypes.INTEGER,
+    },
+  },
+  {
+    tableName: 'trend_rank_history',
+    underscored: true,
+    timestamps: false,
+  },
+);

--- a/sql/202409.sql
+++ b/sql/202409.sql
@@ -1,2 +1,27 @@
 ALTER TABLE evaluation_model_config
     ADD COLUMN `default_value` double NULL AFTER `threshold`;
+
+-- update trend_history
+ALTER TABLE trend_history
+    MODIFY COLUMN data_type INT NOT NULL DEFAULT 0 COMMENT '1 对应 star数,2 对应 contributor数,
+    3 对应 生态评分,4 对应 质量评分';
+
+ALTER TABLE trend_history
+    MODIFY COLUMN date_type INT NOT NULL DEFAULT 0 COMMENT '1 对应 年度数据, 2 对应 月度数据,
+    3 对应 周度数据';
+
+-- create table trend_rank_history
+CREATE TABLE trend_rank_history (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    project_id INT NOT NULL,
+    data_type INT NOT NULL DEFAULT 0 COMMENT '1 对应 star数,2 对应 contributor数,
+    3 对应 生态评分,4 对应 质量评分',
+    increased_value DOUBLE NULL,
+    total_value DOUBLE NULL,
+    date_type INT NOT NULL DEFAULT 0 COMMENT '1 对应 年度数据, 2 对应 月度数据
+    3 对应 周度数据',
+    date DATE NOT NULL,
+    rank_type INT NOT NULL DEFAULT 0 COMMENT '1 对应 增长量排名, 2 对应 总量排名',
+    rank INT NOT NULL DEFAULT 0,
+    UNIQUE(data_type, date_type, date, rank_type, project_id)
+);


### PR DESCRIPTION
添加表trend_rank_history，便于对排名的数据进行基线，以提供历史性的查询