### PR TITLE
feat: trend data baseline establishment implementation

### DIFF
--- a/packages/data-model/models/TrendRankHistory.js
+++ b/packages/data-model/models/TrendRankHistory.js
@@ -30,8 +30,9 @@ export default sequelize.define(
     rankType: {
       type: DataTypes.INTEGER,
     },
-    rank: {
+    rankColumn: {
       type: DataTypes.INTEGER,
+      field: 'rank',
     },
   },
   {

--- a/packages/integration/controllers/trendRankHistory.js
+++ b/packages/integration/controllers/trendRankHistory.js
@@ -1,0 +1,94 @@
+import { logger, sequelize } from '@orginjs/oss-evaluation-data-model';
+import dayjs from 'dayjs';
+
+const DATE_TYPE = {
+  YEAR: 1,
+  MONTH: 2,
+  WEEK: 3,
+};
+
+const DATA_TYPE = {
+  STAR: 1,
+  CONTRIBUTOR: 2,
+  ECOLOGY: 3,
+  QUALITY: 4,
+};
+
+const RANK_TYPE = {
+  INCREASED: {
+    VALUE: 1,
+    ORDER_CRITERIA: `increased_value desc, total_value desc`,
+  },
+  TOTAL: {
+    VALUE: 2,
+    ORDER_CRITERIA: `total_value desc, increased_value desc`,
+  },
+};
+
+async function isValidDateFormat(dateString) {
+  const regex = /^\d{4}-\d{2}-\d{2}$/;
+  return regex.test(dateString);
+}
+
+export async function storeTrendRankHistoryHandler(req, res) {
+  const { dateType, date } = req.query;
+  logger.info(dateType);
+  logger.info(date);
+  await storeTrendRankHistory(dateType, date);
+  res.status(200).send('success');
+}
+
+export async function storeTrendRankHistory(dateType, date = '') {
+  logger.info('Store Trend Rank History');
+  const specifiedDate = (await isValidDateFormat(date)) ? dayjs(date) : dayjs();
+  let selectedDate;
+  if (dateType == DATE_TYPE.YEAR) {
+    selectedDate = specifiedDate.startOf('year').toDate();
+  } else if (dateType == DATE_TYPE.MONTH) {
+    selectedDate = specifiedDate.startOf('month').toDate();
+  } else if (dateType == DATE_TYPE.WEEK) {
+    selectedDate = specifiedDate.startOf('week').toDate();
+  } else {
+    logger.info('Invalid dateType');
+    return;
+  }
+  for (const dataType of [DATA_TYPE.STAR, DATA_TYPE.CONTRIBUTOR]) {
+    for (const rankType of [RANK_TYPE.INCREASED, RANK_TYPE.TOTAL]) {
+      await getRankData(dataType, dateType, selectedDate, rankType);
+    }
+  }
+  if (dateType == DATA_TYPE.WEEK) {
+    return;
+  }
+  for (const dataType of [DATA_TYPE.ECOLOGY, DATA_TYPE.QUALITY]) {
+    for (const rankType of [RANK_TYPE.INCREASED, RANK_TYPE.TOTAL]) {
+      await getRankData(dataType, dateType, selectedDate, rankType);
+    }
+  }
+}
+
+async function getRankData(dataType, dateType, selectedDate, rankType) {
+  const rankTypeValue = rankType.VALUE;
+  const orderCriteria = rankType.ORDER_CRITERIA;
+  const QUERY_SQL = `insert into trend_rank_history(project_id, data_type, date_type,
+      increased_value, total_value, date, rank_type, \`rank\`)
+      select project_id, data_type, date_type, increased_value, total_value, date,
+      :rankTypeValue, row_number() over () as \`rank\`
+      from trend_history
+      where data_type = :dataType
+        and date_type = :dateType
+        and date = :selectedDate
+      order by ${orderCriteria}
+      on duplicate key update
+      increased_value = VALUES(increased_value),
+      total_value = VALUES(total_value),
+      \`rank\` = VALUES(\`rank\`)`;
+  await sequelize
+    .query(QUERY_SQL, {
+      replacements: { rankTypeValue, dataType, dateType, selectedDate },
+      type: sequelize.QueryTypes.INSERT,
+    })
+    .catch(err => {
+      logger.error('Error occurred:', err);
+    });
+}

--- a/packages/integration/routes/sync.js
+++ b/packages/integration/routes/sync.js
@@ -96,6 +96,7 @@ import {
   storeSingleProjectTrendHandler,
   storeAllProjectTrendHandler,
 } from '../controllers/trendHistory.js';
+import { storeTrendRankHistoryHandler } from '../controllers/trendRankHistory.js';
 
 const router = express.Router();
 
@@ -1461,6 +1462,30 @@ router.route('/storeAllProjectTrend').get(storeAllProjectTrendHandler);
  *         description: success.
  */
 router.route('/storeSingleProjectTrend/:repoUrl').get(storeSingleProjectTrendHandler);
+
+/**
+ * @swagger
+ * /sync/storeTrendRankHistory:
+ *   get:
+ *     summary: store trend rank history
+ *     parameters:
+ *     - in: query
+ *       name: dateType
+ *       schema:
+ *         type: number
+ *         example: 2
+ *         required: true
+ *     - in: query
+ *       name: date
+ *       schema:
+ *         type: string
+ *         example: '2024-09-01'
+ *         required: true
+ *     responses:
+ *       200:
+ *         description: Success
+ */
+router.route('/storeTrendRankHistory').get(storeTrendRankHistoryHandler);
 
 /**
  * @swagger

--- a/sql/202409.sql
+++ b/sql/202409.sql
@@ -22,6 +22,6 @@ CREATE TABLE trend_rank_history (
     3 对应 周度数据',
     date DATE NOT NULL,
     rank_type INT NOT NULL DEFAULT 0 COMMENT '1 对应 增长量排名, 2 对应 总量排名',
-    rank INT NOT NULL DEFAULT 0,
+    `rank` INT NOT NULL DEFAULT 0,
     UNIQUE(data_type, date_type, date, rank_type, project_id)
 );


### PR DESCRIPTION
实现排名数据基线，以提供历史性的查询。

1. 接口入参为dateType和date，dateType指定周期类型（1对应年，2对应月，3对应周），date指定周期内的具体日期（自动转化成对应周期内的第一天，不输入则取当前日期）。
2. 周度数据仅同步star和contributor，不考虑生态评分和质量评分。
3. 目前已同步8月和9月的月度数据。
4. 定时器暂未设置，等趋势榜单的周集成功能完成后再进行设置。