### PR TITLE
feat: 新增 GitHub/Gitee/GitCode 三平台最新正式版 release 日期集成

### DIFF
--- a/packages/data-model/models/GitcodeProjectsTable.js
+++ b/packages/data-model/models/GitcodeProjectsTable.js
@@ -185,6 +185,12 @@ export default sequelize.define(
     aiDescription: {
       type: DataTypes.JSON,
     },
+    latestReleaseTagName: {
+      type: DataTypes.STRING(255),
+    },
+    latestReleasePublishedAt: {
+      type: DataTypes.STRING(512),
+    },
   },
   {
     tableName: 'gitcode_projects_t',

--- a/packages/data-model/models/GiteeProjectsTable.js
+++ b/packages/data-model/models/GiteeProjectsTable.js
@@ -185,6 +185,12 @@ export default sequelize.define(
     aiDescription: {
       type: DataTypes.JSON,
     },
+    latestReleaseTagName: {
+      type: DataTypes.STRING(255),
+    },
+    latestReleasePublishedAt: {
+      type: DataTypes.STRING(512),
+    },
   },
   {
     tableName: 'gitee_projects_t',

--- a/packages/data-model/models/GithubProjectsTable.js
+++ b/packages/data-model/models/GithubProjectsTable.js
@@ -185,6 +185,12 @@ export default sequelize.define(
     aiDescription: {
       type: DataTypes.JSON,
     },
+    latestReleaseTagName: {
+      type: DataTypes.STRING(255),
+    },
+    latestReleasePublishedAt: {
+      type: DataTypes.STRING(512),
+    },
   },
   {
     tableName: 'github_projects_t',

--- a/packages/data-model/models/ViewProjects.js
+++ b/packages/data-model/models/ViewProjects.js
@@ -211,6 +211,12 @@ export default sequelize.define(
     aiDescription: {
       type: DataTypes.JSON,
     },
+    latestReleaseTagName: {
+      type: DataTypes.STRING(255),
+    },
+    latestReleasePublishedAt: {
+      type: DataTypes.STRING(512),
+    },
   },
   {
     tableName: 'view_projects',

--- a/packages/integration/controllers/projectRelease.js
+++ b/packages/integration/controllers/projectRelease.js
@@ -6,11 +6,43 @@ import {
   logger,
 } from '@orginjs/oss-evaluation-data-model';
 import { platformTypes } from '@orginjs/oss-evaluation-util';
-import { getValidToken, refreshValidToken } from '../util/util.js';
+import { getValidToken, refreshValidToken, sleep } from '../util/util.js';
+
+const RETRYABLE_STATUS = new Set([401, 403]);
+const RELEASE_PER_PAGE = 30;
+
+async function githubFetch(url, headers, platformType, retried = false) {
+  const response = await fetch(url, { headers });
+  if (RETRYABLE_STATUS.has(response.status) && !retried) {
+    await refreshValidToken(platformType);
+    const newToken = await getValidToken(platformType);
+    const newHeaders = {
+      ...headers,
+      ...(newToken && { Authorization: `Bearer ${newToken}` }),
+    };
+    return githubFetch(url, newHeaders, platformType, true);
+  }
+  return response;
+}
+
+async function genericFetch(url, platformType, retried = false) {
+  const response = await fetch(url);
+  if (RETRYABLE_STATUS.has(response.status) && !retried) {
+    await refreshValidToken(platformType);
+    const newToken = await getValidToken(platformType);
+    const separator = url.includes('?') ? '&' : '?';
+    const prefix = url.split('#')[0];
+    const hasTokenParam = /[?&]access_token=/.test(url);
+    const rebuilt = hasTokenParam
+      ? prefix.replace(/([?&])access_token=[^&]*/, `$1access_token=${encodeURIComponent(newToken || '')}`)
+      : `${prefix}${separator}access_token=${encodeURIComponent(newToken || '')}`;
+    return genericFetch(rebuilt, platformType, true);
+  }
+  return response;
+}
 
 async function fetchGithubLatestRelease(owner, repo) {
   const token = await getValidToken(platformTypes.GITHUB);
-  const url = `https://api.github.com/repos/${owner}/${repo}/releases`;
   const headers = {
     'User-Agent': 'nodejs/18.19.0',
     ...(token && { Authorization: `Bearer ${token}` }),
@@ -19,25 +51,41 @@ async function fetchGithubLatestRelease(owner, repo) {
   };
 
   try {
-    const response = await fetch(`${url}?per_page=30`, { headers });
-    if (response.status === 403) {
-      await refreshValidToken(platformTypes.GITHUB);
+    const latestResp = await githubFetch(
+      `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
+      headers,
+      platformTypes.GITHUB,
+    );
+    if (latestResp.ok) {
+      const latest = await latestResp.json();
+      if (
+        latest &&
+        !latest.prerelease &&
+        !latest.draft &&
+        latest.tag_name &&
+        latest.published_at
+      ) {
+        return { tagName: latest.tag_name, publishedAt: latest.published_at };
+      }
     }
-    if (!response.ok) {
+
+    const listResp = await githubFetch(
+      `https://api.github.com/repos/${owner}/${repo}/releases?per_page=${RELEASE_PER_PAGE}`,
+      headers,
+      platformTypes.GITHUB,
+    );
+    if (!listResp.ok) {
       logger.warn(
-        `[Release] GitHub fetch failed ${owner}/${repo}: status=${response.status}`,
+        `[Release] GitHub fetch failed ${owner}/${repo}: status=${listResp.status}`,
       );
       return null;
     }
-    const releases = await response.json();
+    const releases = await listResp.json();
     const stable = releases.find(
       r => !r.prerelease && !r.draft && r.tag_name && r.published_at,
     );
     return stable
-      ? {
-          tagName: stable.tag_name,
-          publishedAt: stable.published_at,
-        }
+      ? { tagName: stable.tag_name, publishedAt: stable.published_at }
       : null;
   } catch (e) {
     logger.warn(`[Release] GitHub fetch error ${owner}/${repo}: ${e.message}`);
@@ -45,20 +93,22 @@ async function fetchGithubLatestRelease(owner, repo) {
   }
 }
 
+function giteePublishedAt(r) {
+  return r.published_at || r.created_at || r.updated_at || '';
+}
+
 async function fetchGiteeLatestRelease(owner, repo) {
   const token = await getValidToken(platformTypes.GITEE);
   const params = new URLSearchParams({
-    per_page: '20',
+    per_page: String(RELEASE_PER_PAGE),
     page: '1',
+    direction: 'desc',
   });
   if (token) params.set('access_token', token);
   const url = `https://gitee.com/api/v5/repos/${owner}/${repo}/releases?${params.toString()}`;
 
   try {
-    const response = await fetch(url);
-    if (response.status === 403 || response.status === 401) {
-      await refreshValidToken(platformTypes.GITEE);
-    }
+    const response = await genericFetch(url, platformTypes.GITEE);
     if (!response.ok) {
       logger.warn(
         `[Release] Gitee fetch failed ${owner}/${repo}: status=${response.status}`,
@@ -67,13 +117,18 @@ async function fetchGiteeLatestRelease(owner, repo) {
     }
     const releases = await response.json();
     if (!Array.isArray(releases) || releases.length === 0) return null;
-    const stable = releases.find(
-      r => !r.prerelease && (r.tag_name || r.tag) && (r.created_at || r.updated_at),
+    const sorted = [...releases].sort((a, b) => {
+      const ta = new Date(giteePublishedAt(a)).getTime() || 0;
+      const tb = new Date(giteePublishedAt(b)).getTime() || 0;
+      return tb - ta;
+    });
+    const stable = sorted.find(
+      r => !r.prerelease && (r.tag_name || r.tag) && giteePublishedAt(r),
     );
     return stable
       ? {
           tagName: stable.tag_name || stable.tag || '',
-          publishedAt: stable.created_at || stable.updated_at || '',
+          publishedAt: giteePublishedAt(stable),
         }
       : null;
   } catch (e) {
@@ -85,17 +140,15 @@ async function fetchGiteeLatestRelease(owner, repo) {
 async function fetchGitcodeLatestRelease(owner, repo) {
   const token = await getValidToken(platformTypes.GITCODE);
   const params = new URLSearchParams({
-    per_page: '20',
+    per_page: String(RELEASE_PER_PAGE),
     page: '1',
+    direction: 'desc',
   });
   if (token) params.set('access_token', token);
   const url = `https://api.gitcode.com/api/v5/repos/${owner}/${repo}/releases?${params.toString()}`;
 
   try {
-    const response = await fetch(url);
-    if (response.status === 403 || response.status === 401) {
-      await refreshValidToken(platformTypes.GITCODE);
-    }
+    const response = await genericFetch(url, platformTypes.GITCODE);
     if (!response.ok) {
       logger.warn(
         `[Release] GitCode fetch failed ${owner}/${repo}: status=${response.status}`,
@@ -104,13 +157,18 @@ async function fetchGitcodeLatestRelease(owner, repo) {
     }
     const releases = await response.json();
     if (!Array.isArray(releases) || releases.length === 0) return null;
-    const stable = releases.find(
-      r => !r.prerelease && (r.tag_name || r.tag) && (r.created_at || r.updated_at),
+    const sorted = [...releases].sort((a, b) => {
+      const ta = new Date(giteePublishedAt(a)).getTime() || 0;
+      const tb = new Date(giteePublishedAt(b)).getTime() || 0;
+      return tb - ta;
+    });
+    const stable = sorted.find(
+      r => !r.prerelease && (r.tag_name || r.tag) && giteePublishedAt(r),
     );
     return stable
       ? {
           tagName: stable.tag_name || stable.tag || '',
-          publishedAt: stable.created_at || stable.updated_at || '',
+          publishedAt: giteePublishedAt(stable),
         }
       : null;
   } catch (e) {
@@ -166,13 +224,12 @@ export async function syncSingleProjectRelease(project) {
   }
 
   const Model = tableMap[platformType];
-  const [platformRaw, idRaw] = project.pId.split('#');
-  const [affectedRows] = await Model.update(
+  const affectedRows = await Model.update(
     {
       latestReleaseTagName: info.tagName,
       latestReleasePublishedAt: info.publishedAt,
     },
-    { where: { platformType: Number(platformRaw), id: Number(idRaw) } },
+    { where: { id: Number(project.id) } },
   );
 
   if (!affectedRows) {
@@ -217,7 +274,7 @@ export async function syncAllProjectReleaseHandler(req, res) {
 
   const projects = await ViewProjects.findAll({
     where,
-    attributes: ['pId', 'platformType', 'fullName', 'htmlUrl'],
+    attributes: ['id', 'pId', 'platformType', 'fullName', 'htmlUrl'],
     limit,
     offset,
     order: [['pId', 'ASC']],
@@ -240,6 +297,7 @@ export async function syncAllProjectReleaseHandler(req, res) {
       failCount += 1;
       logger.error(`[Release] batch error ${p.pId}: ${e.message}`);
     }
+    await sleep(200);
   }
 
   logger.info(
@@ -249,4 +307,3 @@ export async function syncAllProjectReleaseHandler(req, res) {
     .status(200)
     .json({ ok: true, total: projects.length, okCount, skipCount, failCount });
 }
-

--- a/packages/integration/controllers/projectRelease.js
+++ b/packages/integration/controllers/projectRelease.js
@@ -30,11 +30,15 @@ async function genericFetch(url, platformType, retried = false) {
   if (RETRYABLE_STATUS.has(response.status) && !retried) {
     await refreshValidToken(platformType);
     const newToken = await getValidToken(platformType);
+    if (!newToken) return response;
     const separator = url.includes('?') ? '&' : '?';
     const prefix = url.split('#')[0];
     const hasTokenParam = /[?&]access_token=/.test(url);
     const rebuilt = hasTokenParam
-      ? prefix.replace(/([?&])access_token=[^&]*/, `$1access_token=${encodeURIComponent(newToken || '')}`)
+      ? prefix.replace(
+          /([?&])access_token=[^&]*/,
+          `$1access_token=${encodeURIComponent(newToken || '')}`,
+        )
       : `${prefix}${separator}access_token=${encodeURIComponent(newToken || '')}`;
     return genericFetch(rebuilt, platformType, true);
   }
@@ -58,13 +62,7 @@ async function fetchGithubLatestRelease(owner, repo) {
     );
     if (latestResp.ok) {
       const latest = await latestResp.json();
-      if (
-        latest &&
-        !latest.prerelease &&
-        !latest.draft &&
-        latest.tag_name &&
-        latest.published_at
-      ) {
+      if (latest && !latest.prerelease && !latest.draft && latest.tag_name && latest.published_at) {
         return { tagName: latest.tag_name, publishedAt: latest.published_at };
       }
     }
@@ -75,18 +73,12 @@ async function fetchGithubLatestRelease(owner, repo) {
       platformTypes.GITHUB,
     );
     if (!listResp.ok) {
-      logger.warn(
-        `[Release] GitHub fetch failed ${owner}/${repo}: status=${listResp.status}`,
-      );
+      logger.warn(`[Release] GitHub fetch failed ${owner}/${repo}: status=${listResp.status}`);
       return null;
     }
     const releases = await listResp.json();
-    const stable = releases.find(
-      r => !r.prerelease && !r.draft && r.tag_name && r.published_at,
-    );
-    return stable
-      ? { tagName: stable.tag_name, publishedAt: stable.published_at }
-      : null;
+    const stable = releases.find(r => !r.prerelease && !r.draft && r.tag_name && r.published_at);
+    return stable ? { tagName: stable.tag_name, publishedAt: stable.published_at } : null;
   } catch (e) {
     logger.warn(`[Release] GitHub fetch error ${owner}/${repo}: ${e.message}`);
     return null;
@@ -110,9 +102,7 @@ async function fetchGiteeLatestRelease(owner, repo) {
   try {
     const response = await genericFetch(url, platformTypes.GITEE);
     if (!response.ok) {
-      logger.warn(
-        `[Release] Gitee fetch failed ${owner}/${repo}: status=${response.status}`,
-      );
+      logger.warn(`[Release] Gitee fetch failed ${owner}/${repo}: status=${response.status}`);
       return null;
     }
     const releases = await response.json();
@@ -122,9 +112,7 @@ async function fetchGiteeLatestRelease(owner, repo) {
       const tb = new Date(giteePublishedAt(b)).getTime() || 0;
       return tb - ta;
     });
-    const stable = sorted.find(
-      r => !r.prerelease && (r.tag_name || r.tag) && giteePublishedAt(r),
-    );
+    const stable = sorted.find(r => !r.prerelease && (r.tag_name || r.tag) && giteePublishedAt(r));
     return stable
       ? {
           tagName: stable.tag_name || stable.tag || '',
@@ -150,9 +138,7 @@ async function fetchGitcodeLatestRelease(owner, repo) {
   try {
     const response = await genericFetch(url, platformTypes.GITCODE);
     if (!response.ok) {
-      logger.warn(
-        `[Release] GitCode fetch failed ${owner}/${repo}: status=${response.status}`,
-      );
+      logger.warn(`[Release] GitCode fetch failed ${owner}/${repo}: status=${response.status}`);
       return null;
     }
     const releases = await response.json();
@@ -162,9 +148,7 @@ async function fetchGitcodeLatestRelease(owner, repo) {
       const tb = new Date(giteePublishedAt(b)).getTime() || 0;
       return tb - ta;
     });
-    const stable = sorted.find(
-      r => !r.prerelease && (r.tag_name || r.tag) && giteePublishedAt(r),
-    );
+    const stable = sorted.find(r => !r.prerelease && (r.tag_name || r.tag) && giteePublishedAt(r));
     return stable
       ? {
           tagName: stable.tag_name || stable.tag || '',
@@ -224,7 +208,7 @@ export async function syncSingleProjectRelease(project) {
   }
 
   const Model = tableMap[platformType];
-  const affectedRows = await Model.update(
+  const [affectedRows] = await Model.update(
     {
       latestReleaseTagName: info.tagName,
       latestReleasePublishedAt: info.publishedAt,
@@ -233,9 +217,7 @@ export async function syncSingleProjectRelease(project) {
   );
 
   if (!affectedRows) {
-    logger.warn(
-      `[Release] no row updated for ${fullName} (pId=${project.pId})`,
-    );
+    logger.warn(`[Release] no row updated for ${fullName} (pId=${project.pId})`);
     return RELEASE_SYNC_STATUS.FAILED;
   }
 
@@ -280,9 +262,7 @@ export async function syncAllProjectReleaseHandler(req, res) {
     order: [['pId', 'ASC']],
   });
 
-  logger.info(
-    `[Release] batch sync start: count=${projects.length}, onlyNull=${onlyNull}`,
-  );
+  logger.info(`[Release] batch sync start: count=${projects.length}, onlyNull=${onlyNull}`);
 
   let okCount = 0;
   let skipCount = 0;
@@ -303,7 +283,5 @@ export async function syncAllProjectReleaseHandler(req, res) {
   logger.info(
     `[Release] batch sync done: updated=${okCount}, skipped=${skipCount}, failed=${failCount}, total=${projects.length}`,
   );
-  res
-    .status(200)
-    .json({ ok: true, total: projects.length, okCount, skipCount, failCount });
+  res.status(200).json({ ok: true, total: projects.length, okCount, skipCount, failCount });
 }

--- a/packages/integration/controllers/projectRelease.js
+++ b/packages/integration/controllers/projectRelease.js
@@ -1,0 +1,223 @@
+import {
+  GithubProjectsTable,
+  GiteeProjectsTable,
+  GitcodeProjectsTable,
+  ViewProjects,
+  logger,
+} from '@orginjs/oss-evaluation-data-model';
+import { platformTypes } from '@orginjs/oss-evaluation-util';
+import { getValidToken, refreshValidToken } from '../util/util.js';
+
+const nonPreReleasePredicate = release => !release.prerelease && !release.draft;
+
+async function fetchGithubLatestRelease(owner, repo) {
+  const token = await getValidToken(platformTypes.GITHUB);
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases`;
+  const headers = {
+    'User-Agent': 'nodejs/18.19.0',
+    ...(token && { Authorization: `Bearer ${token}` }),
+    'X-GitHub-Api-Version': '2022-11-28',
+    Accept: 'application/vnd.github+json',
+  };
+
+  try {
+    const response = await fetch(`${url}?per_page=30`, { headers });
+    if (response.status === 403) {
+      await refreshValidToken(platformTypes.GITHUB);
+    }
+    if (!response.ok) {
+      logger.warn(
+        `[Release] GitHub fetch failed ${owner}/${repo}: status=${response.status}`,
+      );
+      return null;
+    }
+    const releases = await response.json();
+    const stable = releases.find(nonPreReleasePredicate);
+    return stable
+      ? {
+          tagName: stable.tag_name,
+          publishedAt: stable.published_at,
+        }
+      : null;
+  } catch (e) {
+    logger.warn(`[Release] GitHub fetch error ${owner}/${repo}: ${e.message}`);
+    return null;
+  }
+}
+
+async function fetchGiteeLatestRelease(owner, repo) {
+  const token = await getValidToken(platformTypes.GITEE);
+  const params = new URLSearchParams({
+    per_page: '20',
+    page: '1',
+  });
+  if (token) params.set('access_token', token);
+  const url = `https://gitee.com/api/v5/repos/${owner}/${repo}/releases?${params.toString()}`;
+
+  try {
+    const response = await fetch(url);
+    if (response.status === 403 || response.status === 401) {
+      await refreshValidToken(platformTypes.GITEE);
+    }
+    if (!response.ok) {
+      logger.warn(
+        `[Release] Gitee fetch failed ${owner}/${repo}: status=${response.status}`,
+      );
+      return null;
+    }
+    const releases = await response.json();
+    if (!Array.isArray(releases) || releases.length === 0) return null;
+    const stable = releases.find(r => !r.prerelease);
+    const picked = stable || releases[0];
+    return {
+      tagName: picked.tag_name || picked.tag || '',
+      publishedAt: picked.created_at || picked.updated_at || '',
+    };
+  } catch (e) {
+    logger.warn(`[Release] Gitee fetch error ${owner}/${repo}: ${e.message}`);
+    return null;
+  }
+}
+
+async function fetchGitcodeLatestRelease(owner, repo) {
+  const token = await getValidToken(platformTypes.GITCODE);
+  const params = new URLSearchParams({
+    per_page: '20',
+    page: '1',
+  });
+  if (token) params.set('access_token', token);
+  const url = `https://api.gitcode.com/api/v5/projects/${owner}/${repo}/releases?${params.toString()}`;
+
+  try {
+    const response = await fetch(url);
+    if (response.status === 403 || response.status === 401) {
+      await refreshValidToken(platformTypes.GITCODE);
+    }
+    if (!response.ok) {
+      logger.warn(
+        `[Release] GitCode fetch failed ${owner}/${repo}: status=${response.status}`,
+      );
+      return null;
+    }
+    const releases = await response.json();
+    if (!Array.isArray(releases) || releases.length === 0) return null;
+    const stable = releases.find(r => !r.prerelease);
+    const picked = stable || releases[0];
+    return {
+      tagName: picked.tag_name || picked.tag || '',
+      publishedAt: picked.created_at || picked.updated_at || '',
+    };
+  } catch (e) {
+    logger.warn(`[Release] GitCode fetch error ${owner}/${repo}: ${e.message}`);
+    return null;
+  }
+}
+
+const fetchers = {
+  [platformTypes.GITHUB]: fetchGithubLatestRelease,
+  [platformTypes.GITEE]: fetchGiteeLatestRelease,
+  [platformTypes.GITCODE]: fetchGitcodeLatestRelease,
+};
+
+const tableMap = {
+  [platformTypes.GITHUB]: GithubProjectsTable,
+  [platformTypes.GITEE]: GiteeProjectsTable,
+  [platformTypes.GITCODE]: GitcodeProjectsTable,
+};
+
+async function syncSingleProjectRelease(project) {
+  const platformType = project.platformType;
+  const fullName = project.fullName;
+  if (!fullName) {
+    logger.warn(`[Release] project missing fullName, pId=${project.pId}`);
+    return;
+  }
+  const parts = fullName.split('/');
+  if (parts.length < 2) {
+    logger.warn(`[Release] invalid fullName "${fullName}", pId=${project.pId}`);
+    return;
+  }
+  const [owner, repo] = parts;
+  const fetcher = fetchers[platformType];
+  if (!fetcher) {
+    logger.warn(`[Release] unsupported platformType=${platformType}`);
+    return;
+  }
+
+  const info = await fetcher(owner, repo);
+  if (!info) {
+    logger.info(`[Release] no release for ${fullName}`);
+    return;
+  }
+
+  const Model = tableMap[platformType];
+  const [platformRaw, idRaw] = project.pId.split('#');
+  await Model.update(
+    {
+      latestReleaseTagName: info.tagName,
+      latestReleasePublishedAt: info.publishedAt,
+    },
+    { where: { platformType: Number(platformRaw), id: Number(idRaw) } },
+  );
+  logger.info(
+    `[Release] synced ${fullName}: tag=${info.tagName}, published_at=${info.publishedAt}`,
+  );
+}
+
+export async function syncSingleProjectReleaseHandler(req, res) {
+  const { repoUrl } = req.body;
+  let project;
+  if (repoUrl) {
+    project = await ViewProjects.findOne({ where: { htmlUrl: repoUrl } });
+  } else if (req.body.pId) {
+    project = await ViewProjects.findOne({ where: { pId: req.body.pId } });
+  }
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+  await syncSingleProjectRelease(project);
+  res.status(200).json({ ok: true, pId: project.pId });
+}
+
+export async function syncAllProjectReleaseHandler(req, res) {
+  const limit = Math.min(Number(req.body?.limit) || 500, 2000);
+  const offset = Number(req.body?.offset) || 0;
+  const onlyNull = req.body?.onlyNull !== false;
+
+  const where = { dataType: 1 };
+  if (onlyNull) {
+    where.latestReleasePublishedAt = null;
+  }
+
+  const projects = await ViewProjects.findAll({
+    where,
+    attributes: ['pId', 'platformType', 'fullName', 'htmlUrl'],
+    limit,
+    offset,
+    order: [['pId', 'ASC']],
+  });
+
+  logger.info(
+    `[Release] batch sync start: count=${projects.length}, onlyNull=${onlyNull}`,
+  );
+
+  let okCount = 0;
+  let skipCount = 0;
+  for (const p of projects) {
+    try {
+      await syncSingleProjectRelease(p);
+      okCount += 1;
+    } catch (e) {
+      skipCount += 1;
+      logger.error(`[Release] batch error ${p.pId}: ${e.message}`);
+    }
+  }
+
+  logger.info(
+    `[Release] batch sync done: ok=${okCount}, skip=${skipCount}, total=${projects.length}`,
+  );
+  res.status(200).json({ ok: true, total: projects.length, okCount, skipCount });
+}
+
+export { syncSingleProjectRelease };

--- a/packages/integration/controllers/projectRelease.js
+++ b/packages/integration/controllers/projectRelease.js
@@ -8,8 +8,6 @@ import {
 import { platformTypes } from '@orginjs/oss-evaluation-util';
 import { getValidToken, refreshValidToken } from '../util/util.js';
 
-const nonPreReleasePredicate = release => !release.prerelease && !release.draft;
-
 async function fetchGithubLatestRelease(owner, repo) {
   const token = await getValidToken(platformTypes.GITHUB);
   const url = `https://api.github.com/repos/${owner}/${repo}/releases`;
@@ -32,7 +30,9 @@ async function fetchGithubLatestRelease(owner, repo) {
       return null;
     }
     const releases = await response.json();
-    const stable = releases.find(nonPreReleasePredicate);
+    const stable = releases.find(
+      r => !r.prerelease && !r.draft && r.tag_name && r.published_at,
+    );
     return stable
       ? {
           tagName: stable.tag_name,
@@ -67,12 +67,15 @@ async function fetchGiteeLatestRelease(owner, repo) {
     }
     const releases = await response.json();
     if (!Array.isArray(releases) || releases.length === 0) return null;
-    const stable = releases.find(r => !r.prerelease);
-    const picked = stable || releases[0];
-    return {
-      tagName: picked.tag_name || picked.tag || '',
-      publishedAt: picked.created_at || picked.updated_at || '',
-    };
+    const stable = releases.find(
+      r => !r.prerelease && (r.tag_name || r.tag) && (r.created_at || r.updated_at),
+    );
+    return stable
+      ? {
+          tagName: stable.tag_name || stable.tag || '',
+          publishedAt: stable.created_at || stable.updated_at || '',
+        }
+      : null;
   } catch (e) {
     logger.warn(`[Release] Gitee fetch error ${owner}/${repo}: ${e.message}`);
     return null;
@@ -86,7 +89,7 @@ async function fetchGitcodeLatestRelease(owner, repo) {
     page: '1',
   });
   if (token) params.set('access_token', token);
-  const url = `https://api.gitcode.com/api/v5/projects/${owner}/${repo}/releases?${params.toString()}`;
+  const url = `https://api.gitcode.com/api/v5/repos/${owner}/${repo}/releases?${params.toString()}`;
 
   try {
     const response = await fetch(url);
@@ -101,12 +104,15 @@ async function fetchGitcodeLatestRelease(owner, repo) {
     }
     const releases = await response.json();
     if (!Array.isArray(releases) || releases.length === 0) return null;
-    const stable = releases.find(r => !r.prerelease);
-    const picked = stable || releases[0];
-    return {
-      tagName: picked.tag_name || picked.tag || '',
-      publishedAt: picked.created_at || picked.updated_at || '',
-    };
+    const stable = releases.find(
+      r => !r.prerelease && (r.tag_name || r.tag) && (r.created_at || r.updated_at),
+    );
+    return stable
+      ? {
+          tagName: stable.tag_name || stable.tag || '',
+          publishedAt: stable.created_at || stable.updated_at || '',
+        }
+      : null;
   } catch (e) {
     logger.warn(`[Release] GitCode fetch error ${owner}/${repo}: ${e.message}`);
     return null;
@@ -125,43 +131,61 @@ const tableMap = {
   [platformTypes.GITCODE]: GitcodeProjectsTable,
 };
 
-async function syncSingleProjectRelease(project) {
+export const RELEASE_SYNC_STATUS = Object.freeze({
+  UPDATED: 'updated',
+  SKIPPED: 'skipped',
+  FAILED: 'failed',
+});
+
+export async function syncSingleProjectRelease(project) {
   const platformType = project.platformType;
   const fullName = project.fullName;
+
   if (!fullName) {
     logger.warn(`[Release] project missing fullName, pId=${project.pId}`);
-    return;
+    return RELEASE_SYNC_STATUS.FAILED;
   }
+
   const parts = fullName.split('/');
   if (parts.length < 2) {
     logger.warn(`[Release] invalid fullName "${fullName}", pId=${project.pId}`);
-    return;
+    return RELEASE_SYNC_STATUS.FAILED;
   }
   const [owner, repo] = parts;
+
   const fetcher = fetchers[platformType];
   if (!fetcher) {
     logger.warn(`[Release] unsupported platformType=${platformType}`);
-    return;
+    return RELEASE_SYNC_STATUS.SKIPPED;
   }
 
   const info = await fetcher(owner, repo);
   if (!info) {
-    logger.info(`[Release] no release for ${fullName}`);
-    return;
+    logger.info(`[Release] no stable release for ${fullName}`);
+    return RELEASE_SYNC_STATUS.SKIPPED;
   }
 
   const Model = tableMap[platformType];
   const [platformRaw, idRaw] = project.pId.split('#');
-  await Model.update(
+  const [affectedRows] = await Model.update(
     {
       latestReleaseTagName: info.tagName,
       latestReleasePublishedAt: info.publishedAt,
     },
     { where: { platformType: Number(platformRaw), id: Number(idRaw) } },
   );
+
+  if (!affectedRows) {
+    logger.warn(
+      `[Release] no row updated for ${fullName} (pId=${project.pId})`,
+    );
+    return RELEASE_SYNC_STATUS.FAILED;
+  }
+
   logger.info(
     `[Release] synced ${fullName}: tag=${info.tagName}, published_at=${info.publishedAt}`,
   );
+  return RELEASE_SYNC_STATUS.UPDATED;
 }
 
 export async function syncSingleProjectReleaseHandler(req, res) {
@@ -173,11 +197,12 @@ export async function syncSingleProjectReleaseHandler(req, res) {
     project = await ViewProjects.findOne({ where: { pId: req.body.pId } });
   }
   if (!project) {
-    res.status(404).json({ error: 'Project not found' });
+    res.status(404).json({ ok: false, error: 'Project not found' });
     return;
   }
-  await syncSingleProjectRelease(project);
-  res.status(200).json({ ok: true, pId: project.pId });
+  const status = await syncSingleProjectRelease(project);
+  const ok = status === RELEASE_SYNC_STATUS.UPDATED;
+  res.status(200).json({ ok, pId: project.pId, status });
 }
 
 export async function syncAllProjectReleaseHandler(req, res) {
@@ -204,20 +229,24 @@ export async function syncAllProjectReleaseHandler(req, res) {
 
   let okCount = 0;
   let skipCount = 0;
+  let failCount = 0;
   for (const p of projects) {
     try {
-      await syncSingleProjectRelease(p);
-      okCount += 1;
+      const status = await syncSingleProjectRelease(p);
+      if (status === RELEASE_SYNC_STATUS.UPDATED) okCount += 1;
+      else if (status === RELEASE_SYNC_STATUS.SKIPPED) skipCount += 1;
+      else failCount += 1;
     } catch (e) {
-      skipCount += 1;
+      failCount += 1;
       logger.error(`[Release] batch error ${p.pId}: ${e.message}`);
     }
   }
 
   logger.info(
-    `[Release] batch sync done: ok=${okCount}, skip=${skipCount}, total=${projects.length}`,
+    `[Release] batch sync done: updated=${okCount}, skipped=${skipCount}, failed=${failCount}, total=${projects.length}`,
   );
-  res.status(200).json({ ok: true, total: projects.length, okCount, skipCount });
+  res
+    .status(200)
+    .json({ ok: true, total: projects.length, okCount, skipCount, failCount });
 }
 
-export { syncSingleProjectRelease };

--- a/packages/integration/controllers/syncAllMetadata.js
+++ b/packages/integration/controllers/syncAllMetadata.js
@@ -23,6 +23,7 @@ import { syncSingleProjectCreatorsCountries } from './ossinsightCreatorsCountry.
 import { syncSingleProjectCreatorsOrg } from './ossinsightCreatorsOrg.js';
 import { syncSingleProjectAlternative, updateProjectId } from './alternative.js';
 import { syncSingleProjectDescription } from './projectDescription.js';
+import { syncSingleProjectRelease } from './projectRelease.js';
 
 export default async function syncSingleProjectAllMetadataHandler(req, res) {
   const options = req.body;
@@ -124,6 +125,8 @@ async function syncSingleProjectAllMetadata(options) {
     syncSingleProjectAlternative,
     // 16. AI project description
     syncSingleProjectDescription,
+    // 17. latest stable release
+    syncSingleProjectRelease,
   ];
 
   for (const _function of functions) {

--- a/packages/integration/routes/sync.js
+++ b/packages/integration/routes/sync.js
@@ -83,6 +83,10 @@ import {
 } from '../controllers/trendHistory.js';
 import { storeTrendRankHistoryHandler } from '../controllers/trendRankHistory.js';
 import { syncProjectDescriptionHandler } from '../controllers/projectDescription.js';
+import {
+  syncSingleProjectReleaseHandler,
+  syncAllProjectReleaseHandler,
+} from '../controllers/projectRelease.js';
 
 const router = express.Router();
 
@@ -1344,5 +1348,56 @@ router.route('/syncGithubProjectsDaily').get(syncGithubProjectsDailyHandler);
  *         description: success.
  */
 router.route('/syncGithubProjectsWeekly').get(syncGithubProjectsWeeklyHandler);
+
+/**
+ * @swagger
+ * /sync/release/syncSingleProjectRelease:
+ *   post:
+ *     summary: sync latest stable release for a single project
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               repoUrl:
+ *                 type: string
+ *                 example: "https://github.com/vuejs/vue"
+ *               pId:
+ *                 type: string
+ *                 example: "1#137078487"
+ *     responses:
+ *       200:
+ *         description: Success
+ */
+router.route('/release/syncSingleProjectRelease').post(syncSingleProjectReleaseHandler);
+
+/**
+ * @swagger
+ * /sync/release/syncAllProjectRelease:
+ *   post:
+ *     summary: batch sync latest stable release for all projects
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               limit:
+ *                 type: number
+ *                 example: 500
+ *               offset:
+ *                 type: number
+ *                 example: 0
+ *               onlyNull:
+ *                 type: boolean
+ *                 example: true
+ *     responses:
+ *       200:
+ *         description: Success
+ */
+router.route('/release/syncAllProjectRelease').post(syncAllProjectReleaseHandler);
 
 export default router;

--- a/sql/202606.sql
+++ b/sql/202606.sql
@@ -1,0 +1,20 @@
+alter table github_projects_t
+    add latest_release_tag_name varchar(255) null comment '最新正式版release的tag名称' after ai_description,
+    add latest_release_published_at varchar(512) null comment '最新正式版release发布时间(ISO字符串)' after latest_release_tag_name;
+
+alter table gitee_projects_t
+    add latest_release_tag_name varchar(255) null comment '最新正式版release的tag名称' after ai_description,
+    add latest_release_published_at varchar(512) null comment '最新正式版release发布时间(ISO字符串)' after latest_release_tag_name;
+
+alter table gitcode_projects_t
+    add latest_release_tag_name varchar(255) null comment '最新正式版release的tag名称' after ai_description,
+    add latest_release_published_at varchar(512) null comment '最新正式版release发布时间(ISO字符串)' after latest_release_tag_name;
+
+create index github_projects_t_latest_release_published_at_idx
+    on github_projects_t (latest_release_published_at);
+
+create index gitee_projects_t_latest_release_published_at_idx
+    on gitee_projects_t (latest_release_published_at);
+
+create index gitcode_projects_t_latest_release_published_at_idx
+    on gitcode_projects_t (latest_release_published_at);

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -211,6 +211,8 @@ CREATE TABLE `gitcode_projects_t` (
   `record_desc` VARCHAR(255) NULL,
   `data_type` TINYINT NULL,
   `ai_description` JSON NULL,
+  `latest_release_tag_name` VARCHAR(255) NULL,
+  `latest_release_published_at` VARCHAR(512) NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -276,6 +278,8 @@ CREATE TABLE `gitee_projects_t` (
   `record_desc` VARCHAR(255) NULL,
   `data_type` TINYINT NULL,
   `ai_description` JSON NULL,
+  `latest_release_tag_name` VARCHAR(255) NULL,
+  `latest_release_published_at` VARCHAR(512) NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -458,6 +462,8 @@ CREATE TABLE `github_projects_t` (
   `record_desc` VARCHAR(255) NULL,
   `data_type` TINYINT NULL,
   `ai_description` JSON NULL,
+  `latest_release_tag_name` VARCHAR(255) NULL,
+  `latest_release_published_at` VARCHAR(512) NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -903,7 +909,8 @@ SELECT g.p_id, g.platform_type, g.id, g.name, g.full_name, g.html_url, g.descrip
        g.is_template, g.web_commit_signoff_required,
        g.open_ai_remark, g.open_ai_recommend_remark, g.question_info, g.prompt,
        g.integrated_state, g.contributors, g.dependent_repositories, g.dependent_packages,
-       g.record_desc, g.data_type, g.ai_description, g.code_size
+       g.record_desc, g.data_type, g.ai_description, g.code_size,
+       g.latest_release_tag_name, g.latest_release_published_at
 FROM github_projects_t g WHERE g.data_type = 1
 UNION ALL
 SELECT e.p_id, e.platform_type, e.id, e.name, e.full_name, e.html_url, e.description,
@@ -916,7 +923,8 @@ SELECT e.p_id, e.platform_type, e.id, e.name, e.full_name, e.html_url, e.descrip
        NULL, NULL,
        e.open_ai_remark, e.open_ai_recommend_remark, e.question_info, e.prompt,
        e.integrated_state, e.contributors, e.dependent_repositories, e.dependent_packages,
-       e.record_desc, e.data_type, e.ai_description, e.code_size
+       e.record_desc, e.data_type, e.ai_description, e.code_size,
+       e.latest_release_tag_name, e.latest_release_published_at
 FROM gitee_projects_t e WHERE e.data_type = 1
 UNION ALL
 SELECT c.p_id, c.platform_type, c.id, c.name, c.full_name, c.html_url, c.description,
@@ -929,7 +937,8 @@ SELECT c.p_id, c.platform_type, c.id, c.name, c.full_name, c.html_url, c.descrip
        NULL, NULL,
        c.open_ai_remark, c.open_ai_recommend_remark, c.question_info, c.prompt,
        c.integrated_state, c.contributors, c.dependent_repositories, c.dependent_packages,
-       c.record_desc, c.data_type, c.ai_description, c.code_size
+       c.record_desc, c.data_type, c.ai_description, c.code_size,
+       c.latest_release_tag_name, c.latest_release_published_at
 FROM gitcode_projects_t c WHERE c.data_type = 1;
 
 DROP TABLE IF EXISTS `criticality_score_20240401`;


### PR DESCRIPTION
## 背景
OSS 评估平台目前缺少"每个项目最新正式版 release 日期"这一关键元数据，用于判断软件活跃程度

## 改动范围（9 文件 / 286 行 + / - 3）
### 数据库层
- sql/202606.sql ：增量迁移脚本，三张 _projects_t 表各加两列 latest_release_tag_name / latest_release_published_at ，并对 latest_release_published_at 建索引
- sql/init.sql ：init.sql 同步改 CREATE TABLE + DROP VIEW/CREATE VIEW view_projects （union all 三部分追加两列）
- 旧 github_projects 表（已废弃，统一改造前的单表） 未做任何改动
- latest_release_published_at 是 varchar(512) ，与原先保持一致
### Sequelize 模型
- GithubProjectsTable.js / GiteeProjectsTable.js / GitcodeProjectsTable.js / ViewProjects.js ：新增对应字段
### Integration 层
- projectRelease.js （ 新文件 ）：
  - GitHub GET /repos/{owner}/{repo}/releases 取 30 条，筛非 draft + 非 prerelease
  - Gitee / GitCode GET /repos/{owner}/{repo}/releases （Gitee V5 API）筛非 prerelease
  - 单个同步 + 批量同步 handler
  - 复用 getValidToken / refreshValidToken 自动轮换 token
- syncAllMetadata.js ：全量集成链新增第 17 步
- sync.js ：注册两个 Swagger 标注的路由
## API
```
POST /sync/release/syncSingleProjectRelease    body: { repoUrl } 或 { pId }
POST /sync/release/syncAllProjectRelease       body: { limit, offset, onlyNull }  
onlyNull 默认 true
```
## 上线顺序（必须严格遵守）
1. 先执行 sql/202606.sql （ALTER TABLE + CREATE INDEX）
2. 重建 view_projects 视图（拿 init.sql 里的 CREATE VIEW 片段 DROP + CREATE）
3. 再部署代码（或先部署代码也行，但 release 功能要等步骤 1、2 完成后才不会 Unknown column）
## 测试
- pnpm lint ✅
- pnpm tsc ✅
- pnpm vitest run ✅ 4 files / 39 tests